### PR TITLE
Replaced {{key}} interpolation for %{key}

### DIFF
--- a/remarkable/README
+++ b/remarkable/README
@@ -133,12 +133,12 @@ file. A file for this example would be:
   remarkable:
     active_record:
       validate_inclusion_of:
-        description: "validate inclusion of {{attribute}}"
+        description: "validate inclusion of %{attribute}"
         expectations:
-          is_valid: "to be valid when {{attribute}} is {{value}}"
+          is_valid: "to be valid when %{attribute} is %{value}"
         optionals:
           in:
-            positive: "in {{inspect}}"
+            positive: "in %{inspect}"
           allow_nil:
             positive: "allowing nil values"
             negative: "not allowing nil values"
@@ -198,7 +198,7 @@ Whenever running the assertion, it will also set the @attribute (in singular)
 variable. In your I18n files, you just need to change your description:
 
       validate_inclusion_of:
-        description: "validate inclusion of {{attributes}}"
+        description: "validate inclusion of %{attributes}"
 
 And this will output:
 

--- a/remarkable/lib/remarkable/dsl/assertions.rb
+++ b/remarkable/lib/remarkable/dsl/assertions.rb
@@ -101,11 +101,11 @@ module Remarkable
           #   class InRange < Remarkable::Base
           #     arguments :range, :collection => :names, :as => :name
           #
-          # You will have {{range}}, {{names}} and {{name}} available for I18n
+          # You will have %{range}, %{names} and %{name} available for I18n
           # messages:
           #
           #   in_range:
-          #     description: "have {{names}} to be on range {{range}}"
+          #     description: "have %{names} to be on range %{range}"
           #
           # Before a collection is sent to I18n, it's transformed to a sentence.
           # So if the following matcher:
@@ -216,13 +216,13 @@ module Remarkable
           # case, the error message would be on:
           #
           #   included:
-          #     description: "check {{value}} is included in the array"
+          #     description: "check %{value} is included in the array"
           #     expectations:
-          #       is_included: "{{value}} is included in the array"
+          #       is_included: "%{value} is included in the array"
           #
           # In case of failure, it will output:
           #
-          #   "Expected {{value}} is included in the array"
+          #   "Expected %{value} is included in the array"
           #
           # Notice that on the yml file the question mark is removed for readability.
           #

--- a/remarkable/lib/remarkable/dsl/optionals.rb
+++ b/remarkable/lib/remarkable/dsl/optionals.rb
@@ -48,10 +48,10 @@ module Remarkable
     # properly on your locale file. If you have a validate_uniqueness_of
     # matcher with the following on your locale file:
     #
-    #   description: validate uniqueness of {{attributes}}
+    #   description: validate uniqueness of %{attributes}
     #   optionals:
     #     scope:
-    #       positive: scoped to {{inspect}}
+    #       positive: scoped to %{inspect}
     #     case_sensitive:
     #       positive: case sensitive
     #       negative: case insensitive
@@ -70,7 +70,7 @@ module Remarkable
     # == Interpolation options
     #
     # The default interpolation options available are "inspect" and "value". Whenever
-    # you use :splat => true, it also adds a new interpolation option called {{sentence}}.
+    # you use :splat => true, it also adds a new interpolation option called %{sentence}.
     #
     # Given the following matcher call:
     #
@@ -79,13 +79,13 @@ module Remarkable
     # The following yml setting and outputs are:
     #
     #    scope:
-    #      positive: scoped to {{inspect}}
+    #      positive: scoped to %{inspect}
     #      # Outputs: "validate uniqueness of project_id scoped to [ :company_id, :project_id ]"
     #
-    #      positive: scoped to {{value}}
+    #      positive: scoped to %{value}
     #      # Outputs: "validate uniqueness of project_id scoped to company_idproject_id"
     #
-    #      positive: scoped to {{value}}
+    #      positive: scoped to %{value}
     #      # Outputs: "validate uniqueness of project_id scoped to company_id and project_id"
     #
     # == Interpolation keys

--- a/remarkable/locale/en.yml
+++ b/remarkable/locale/en.yml
@@ -5,8 +5,8 @@ en:
       should: "should"
       should_not: "should not"
       example_disabled: "Example disabled"
-      failure_message_for_should: "Expected {{expectation}}"
-      failure_message_for_should_not: "Did not expect {{expectation}}"
+      failure_message_for_should: "Expected %{expectation}"
+      failure_message_for_should_not: "Did not expect %{expectation}"
 
       helpers:
         words_connector: ", "

--- a/remarkable/spec/locale/en.yml
+++ b/remarkable/spec/locale/en.yml
@@ -8,18 +8,18 @@ en:
       contain:
         description: "contain the given values"
       single_contain:
-        description: "contain {{value}}"
+        description: "contain %{value}"
         optionals:
           allow_nil:
             positive: "allowing nil"
             negative: "not allowing nil"
           allow_blank:
-            positive: "with blank equal {{inspect}}"
+            positive: "with blank equal %{inspect}"
             not_given: "not checking for blank"
           values:
-            positive: "values equal to {{sentence}}"
+            positive: "values equal to %{sentence}"
       collection_contain:
-        description: "contain {{values}}"
+        description: "contain %{values}"
         expectations:
-          included: "{{more}}{{value}} is included in {{subject_inspect}}"
-          is_array?: "subject is a array, but got {{subject_name}}"
+          included: "%{more}%{value} is included in %{subject_inspect}"
+          is_array?: "subject is a array, but got %{subject_name}"

--- a/remarkable/spec/locale/pt-BR.yml
+++ b/remarkable/spec/locale/pt-BR.yml
@@ -5,8 +5,8 @@ pt-BR:
       should: deve
       should_not: não deve
       example_disabled: Exemplo desativado
-      failure_message_for_should: Esperava que {{expectation}}
-      failure_message_for_should_not: Não esperava que {{expectation}}
+      failure_message_for_should: Esperava que %{expectation}
+      failure_message_for_should_not: Não esperava que %{expectation}
 
       helpers:
         words_connector: ', '
@@ -17,5 +17,5 @@ pt-BR:
       collection_contain:
         description: "conter os valores fornecidos"
         expectations:
-          included: "{{value}} estivesse incluso em {{subject_inspect}}"
-          is_array?: "valor dado é um array, mas é {{subject_name}}"
+          included: "%{value} estivesse incluso em %{subject_inspect}"
+          is_array?: "valor dado é um array, mas é %{subject_name}"

--- a/remarkable_activerecord/lib/remarkable_activerecord/base.rb
+++ b/remarkable_activerecord/lib/remarkable_activerecord/base.rb
@@ -175,7 +175,7 @@ module Remarkable
         #   Using the underlying mechanism inside ActiveRecord makes us free from
         #   all thos errors.
         #
-        # We replace {{count}} interpolation for 12345 which later is replaced
+        # We replace %{count} interpolation for 12345 which later is replaced
         # by a regexp which contains \d+.
         #
         def error_message_from_model(model, attribute, message) #:nodoc:

--- a/remarkable_activerecord/lib/remarkable_activerecord/describe.rb
+++ b/remarkable_activerecord/lib/remarkable_activerecord/describe.rb
@@ -33,7 +33,7 @@ module Remarkable
     #     remarkable:
     #       active_record:
     #         describe:
-    #           each: "{{key}} is {{value}}"
+    #           each: "%{key} is %{value}"
     #           prepend: "when "
     #           connector: " and "
     #
@@ -98,7 +98,7 @@ module Remarkable
         #     remarkable:
         #       active_record:
         #         describe:
-        #           each: "{{key}} is {{value}}"
+        #           each: "%{key} is %{value}"
         #           prepend: "when "
         #           connector: " and "
         #
@@ -125,7 +125,7 @@ module Remarkable
               end
 
               pieces << Remarkable.t("remarkable.active_record.describe.each",
-                                      :default => "{{key}} is {{value}}",
+                                      :default => "%{key} is %{value}",
                                       :key => translated_key.downcase, :value => value.inspect)
             end
 

--- a/remarkable_activerecord/locale/en.yml
+++ b/remarkable_activerecord/locale/en.yml
@@ -2,12 +2,12 @@ en:
   remarkable:
     active_record:
       describe:
-        each: "{{key}} is {{value}}"
+        each: "%{key} is %{value}"
         prepend: "when "
         connector: " and "
       expectations:
-        allow_nil: "{{subject_name}} to {{not}}allow nil values for {{attribute}}"
-        allow_blank: "{{subject_name}} to {{not}}allow blank values for {{attribute}}"
+        allow_nil: "%{subject_name} to %{not}allow nil values for %{attribute}"
+        allow_blank: "%{subject_name} to %{not}allow blank values for %{attribute}"
       optionals:
         allow_nil:
           positive: "allowing nil values"
@@ -17,71 +17,71 @@ en:
           negative: "not allowing blank values"
 
       accept_nested_attributes_for:
-        description: "accept nested attributes for {{associations}}"
+        description: "accept nested attributes for %{associations}"
         expectations:
-          association_exists: "{{subject_name}} to have association {{association}}, but does not"
-          is_autosave: "{{subject_name}} to have association {{association}} with autosave true, got false"
-          responds_to_attributes: "{{subject_name}} to respond to :{{association}}_attributes=, but does not"
-          allows_destroy: "{{subject_name}} with allow destroy equals to {{allow_destroy}}, got {{actual}}"
-          accepts: "{{subject_name}} to accept attributes {{attributes}} for {{association}}, but does not"
-          rejects: "{{subject_name}} to reject attributes {{attributes}} for {{association}}, but does not"
+          association_exists: "%{subject_name} to have association %{association}, but does not"
+          is_autosave: "%{subject_name} to have association %{association} with autosave true, got false"
+          responds_to_attributes: "%{subject_name} to respond to :%{association}_attributes=, but does not"
+          allows_destroy: "%{subject_name} with allow destroy equals to %{allow_destroy}, got %{actual}"
+          accepts: "%{subject_name} to accept attributes %{attributes} for %{association}, but does not"
+          rejects: "%{subject_name} to reject attributes %{attributes} for %{association}, but does not"
         optionals:
           allow_destroy:
             positive: "allowing destroy"
             negative: "not allowing destroy"
           accept:
-            positive: "accepting {{sentence}}"
+            positive: "accepting %{sentence}"
           reject:
-            positive: "rejecting {{sentence}}"
+            positive: "rejecting %{sentence}"
 
       allow_values_for:
-        description: "allow {{in}} as values for {{attributes}}"
+        description: "allow %{in} as values for %{attributes}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
 
       allow_mass_assignment_of:
-        description: "allow mass assignment of {{attributes}}"
+        description: "allow mass assignment of %{attributes}"
         expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} is protecting {{protected_attributes}})"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has not made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} is protecting %{protected_attributes})"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has not made %{attribute} accessible)"
         negative_expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} made {{accessible_attributes}} accessible)"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is not protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} made %{accessible_attributes} accessible)"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is not protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has made %{attribute} accessible)"
 
       association:
         belongs_to: belong to
         has_many: have many
         has_and_belongs_to_many: have and belong to many
         has_one: have one
-        description: "{{macro}} {{associations}}"
+        description: "%{macro} %{associations}"
         expectations:
-          association_exists: "{{subject_name}} records {{macro}} {{association}}, but the association does not exist"
-          macro_matches: "{{subject_name}} records {{macro}} {{association}}, got {{subject_name}} records {{actual_macro}} {{association}}"
-          through_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, through association does not exist"
-          source_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, source association does not exist"
-          klass_exists: "{{subject_name}} records {{macro}} {{association}}, but the association class does not exist"
-          join_table_exists: "join table {{join_table}} to exist, but does not"
-          foreign_key_exists: "foreign key {{foreign_key}} to exist on {{foreign_key_table}}, but does not"
-          polymorphic_exists: "{{subject_table}} to have {{polymorphic_column}} as column, but does not"
-          counter_cache_exists: "{{reflection_table}} to have {{counter_cache_column}} as column, but does not"
-          options_match: "{{subject_name}} records {{macro}} {{association}} with options {{options}}, got {{actual}}"
+          association_exists: "%{subject_name} records %{macro} %{association}, but the association does not exist"
+          macro_matches: "%{subject_name} records %{macro} %{association}, got %{subject_name} records %{actual_macro} %{association}"
+          through_exists: "%{subject_name} records %{macro} %{association} through %{through}, through association does not exist"
+          source_exists: "%{subject_name} records %{macro} %{association} through %{through}, source association does not exist"
+          klass_exists: "%{subject_name} records %{macro} %{association}, but the association class does not exist"
+          join_table_exists: "join table %{join_table} to exist, but does not"
+          foreign_key_exists: "foreign key %{foreign_key} to exist on %{foreign_key_table}, but does not"
+          polymorphic_exists: "%{subject_table} to have %{polymorphic_column} as column, but does not"
+          counter_cache_exists: "%{reflection_table} to have %{counter_cache_column} as column, but does not"
+          options_match: "%{subject_name} records %{macro} %{association} with options %{options}, got %{actual}"
         optionals:
           through:
-            positive: "through {{value}}"
+            positive: "through %{value}"
           source:
-            positive: "with source {{inspect}}"
+            positive: "with source %{inspect}"
           source_type:
-            positive: "with source type {{inspect}}"
+            positive: "with source type %{inspect}"
           class_name:
-            positive: "with class name {{inspect}}"
+            positive: "with class name %{inspect}"
           foreign_key:
-            positive: "with foreign key {{inspect}}"
+            positive: "with foreign key %{inspect}"
           dependent:
-            positive: "with dependent {{inspect}}"
+            positive: "with dependent %{inspect}"
           join_table:
-            positive: "with join table {{inspect}}"
+            positive: "with join table %{inspect}"
           uniq:
             positive: "with unique records"
             negative: "without unique records"
@@ -95,136 +95,136 @@ en:
             positive: "autosaving associated records"
             negative: "not autosaving associated records"
           as:
-            positive: "through the polymorphic interface {{inspect}}"
+            positive: "through the polymorphic interface %{inspect}"
           counter_cache:
-            positive: "with counter cache {{inspect}}"
+            positive: "with counter cache %{inspect}"
             negative: "without counter cache"
           select:
-            positive: "selecting {{inspect}}"
+            positive: "selecting %{inspect}"
           conditions:
-            positive: "with conditions {{inspect}}"
+            positive: "with conditions %{inspect}"
           include:
-            positive: "including {{inspect}}"
+            positive: "including %{inspect}"
           group:
-            positive: "grouping by {{inspect}}"
+            positive: "grouping by %{inspect}"
           having:
-            positive: "having {{inspect}}"
+            positive: "having %{inspect}"
           order:
-            positive: "with order {{inspect}}"
+            positive: "with order %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
           offset:
-            positive: "with offset {{inspect}}"
+            positive: "with offset %{inspect}"
 
       have_column:
-        description: "have column(s) named {{columns}}"
+        description: "have column(s) named %{columns}"
         expectations:
-          column_exists: "{{subject_name}} to have column named {{column}}"
-          options_match: "{{subject_name}} to have column {{column}} with options {{options}}, got {{actual}}"
+          column_exists: "%{subject_name} to have column named %{column}"
+          options_match: "%{subject_name} to have column %{column} with options %{options}, got %{actual}"
         optionals:
           type:
-            positive: "with type {{inspect}}"
+            positive: "with type %{inspect}"
           null:
             positive: "allowing null values"
             negative: "not allowing null values"
           default:
-            positive: "with default value {{inspect}}"
-            negative: "with default value {{inspect}}"
+            positive: "with default value %{inspect}"
+            negative: "with default value %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
 
       have_default_scope:
-        description: "have a default scope with {{options}}"
+        description: "have a default scope with %{options}"
         expectations:
-          options_match: "default scope with {{options}}, got {{actual}}"
+          options_match: "default scope with %{options}, got %{actual}"
 
       have_index:
-        description: "have index for column(s) {{columns}}"
+        description: "have index for column(s) %{columns}"
         expectations:
-          index_exists: "index {{column}} to exist on table {{table_name}}"
-          is_unique: "index on {{column}} with unique equals to {{unique}}, got {{actual}}"
+          index_exists: "index %{column} to exist on table %{table_name}"
+          is_unique: "index on %{column} with unique equals to %{unique}, got %{actual}"
         optionals:
           unique:
             positive: "with unique values"
             negative: "with non unique values"
           table_name:
-            positive: "on table {{value}}"
+            positive: "on table %{value}"
 
       have_readonly_attributes:
-        description: "make {{attributes}} read-only"
+        description: "make %{attributes} read-only"
         expectations:
-          is_readonly: "{{subject_name}} to make {{attribute}} read-only, got {{actual}}"
+          is_readonly: "%{subject_name} to make %{attribute} read-only, got %{actual}"
 
       have_scope:
-        description: "have to scope itself to {{options}} when {{scope_name}} is called"
+        description: "have to scope itself to %{options} when %{scope_name} is called"
         expectations:
-          is_scope: "{{scope_name}} when called on {{subject_name}} return an instance of ActiveRecord::NamedScope::Scope"
-          options_match: "{{scope_name}} when called on {{subject_name}} scope to {{options}}, got {{actual}}"
+          is_scope: "%{scope_name} when called on %{subject_name} return an instance of ActiveRecord::NamedScope::Scope"
+          options_match: "%{scope_name} when called on %{subject_name} scope to %{options}, got %{actual}"
         optionals:
           with:
-            positive: "with {{inspect}} as argument"
+            positive: "with %{inspect} as argument"
 
       validate_acceptance_of:
-        description: "require {{attributes}} to be accepted"
+        description: "require %{attributes} to be accepted"
         expectations:
-          requires_acceptance: "{{subject_name}} to be invalid if {{attribute}} is not accepted"
-          accept_is_valid: "{{subject_name}} to be valid when {{attribute}} is accepted with value {{accept}}"
+          requires_acceptance: "%{subject_name} to be invalid if %{attribute} is not accepted"
+          accept_is_valid: "%{subject_name} to be valid when %{attribute} is accepted with value %{accept}"
         optionals:
           accept:
-            positive: "with value {{inspect}}"
+            positive: "with value %{inspect}"
 
       validate_associated:
-        description: "require associated {{associations}} to be valid"
+        description: "require associated %{associations} to be valid"
         expectations:
-          is_valid: "{{subject_name}} to be invalid when {{association}} is invalid"
+          is_valid: "%{subject_name} to be invalid when %{association} is invalid"
 
       validate_confirmation_of:
-        description: "require {{attributes}} to be confirmed"
+        description: "require %{attributes} to be confirmed"
         expectations:
-          responds_to_confirmation: "{{subject_name}} instance responds to {{attribute}}_confirmation"
-          confirms: "{{subject_name}} to be valid only when {{attribute}} is confirmed"
+          responds_to_confirmation: "%{subject_name} instance responds to %{attribute}_confirmation"
+          confirms: "%{subject_name} to be valid only when %{attribute} is confirmed"
 
       validate_exclusion_of:
-        description: "ensure exclusion of {{attributes}} in {{in}}"
+        description: "ensure exclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_inclusion_of:
-        description: "ensure inclusion of {{attributes}} in {{in}}"
+        description: "ensure inclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_length_of:
-        description: "ensure length of {{attributes}}"
+        description: "ensure length of %{attributes}"
         expectations:
-          less_than_min_length: "{{subject_name}} to be invalid when {{attribute}} length is less than {{minimum}} characters"
-          exactly_min_length: "{{subject_name}} to be valid when {{attribute}} length is {{minimum}} characters"
-          more_than_max_length: "{{subject_name}} to be invalid when {{attribute}} length is more than {{maximum}} characters"
-          exactly_max_length: "{{subject_name}} to be valid when {{attribute}} length is {{maximum}} characters"
+          less_than_min_length: "%{subject_name} to be invalid when %{attribute} length is less than %{minimum} characters"
+          exactly_min_length: "%{subject_name} to be valid when %{attribute} length is %{minimum} characters"
+          more_than_max_length: "%{subject_name} to be invalid when %{attribute} length is more than %{maximum} characters"
+          exactly_max_length: "%{subject_name} to be valid when %{attribute} length is %{maximum} characters"
         optionals:
           within:
-            positive: "is within {{inspect}} characters"
+            positive: "is within %{inspect} characters"
           maximum:
-            positive: "is maximum {{inspect}} characters"
+            positive: "is maximum %{inspect} characters"
           minimum:
-            positive: "is minimum {{inspect}} characters"
+            positive: "is minimum %{inspect} characters"
           is:
-            positive: "is equal to {{inspect}} characters"
+            positive: "is equal to %{inspect} characters"
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       validate_numericality_of:
-        description: "ensure numericality of {{attributes}}"
+        description: "ensure numericality of %{attributes}"
         expectations:
-          only_numeric_values: "{{subject_name}} to allow only numeric values for {{attribute}}"
-          only_integer: "{{subject_name}} to {{not}}allow only integer values for {{attribute}}"
-          only_even: "{{subject_name}} to allow only even values for {{attribute}}"
-          only_odd: "{{subject_name}} to allow only odd values for {{attribute}}"
-          equals_to: "{{subject_name}} to be valid only when {{attribute}} is equal to {{count}}"
-          more_than_maximum: "{{subject_name}} to be invalid when {{attribute}} is greater than {{count}}"
-          less_than_minimum: "{{subject_name}} to be invalid when {{attribute}} is less than {{count}}"
+          only_numeric_values: "%{subject_name} to allow only numeric values for %{attribute}"
+          only_integer: "%{subject_name} to %{not}allow only integer values for %{attribute}"
+          only_even: "%{subject_name} to allow only even values for %{attribute}"
+          only_odd: "%{subject_name} to allow only odd values for %{attribute}"
+          equals_to: "%{subject_name} to be valid only when %{attribute} is equal to %{count}"
+          more_than_maximum: "%{subject_name} to be invalid when %{attribute} is greater than %{count}"
+          less_than_minimum: "%{subject_name} to be invalid when %{attribute} is less than %{count}"
         optionals:
           only_integer:
             positive: "allowing only integer values"
@@ -233,31 +233,31 @@ en:
           even:
             positive: "allowing only even values"
           equal_to:
-            positive: "is equal to {{inspect}}"
+            positive: "is equal to %{inspect}"
           less_than:
-            positive: "is less than {{inspect}}"
+            positive: "is less than %{inspect}"
           greater_than:
-            positive: "is greater than {{inspect}}"
+            positive: "is greater than %{inspect}"
           less_than_or_equal_to:
-            positive: "is less than or equal to {{inspect}}"
+            positive: "is less than or equal to %{inspect}"
           greater_than_or_equal_to:
-            positive: "is greater than or equal to {{inspect}}"
+            positive: "is greater than or equal to %{inspect}"
 
       validate_presence_of:
-        description: "require {{attributes}} to be set"
+        description: "require %{attributes} to be set"
         expectations:
-          allow_nil: "{{subject_name}} to require {{attribute}} to be set"
+          allow_nil: "%{subject_name} to require %{attribute} to be set"
 
       validate_uniqueness_of:
-        description: "require unique values for {{attributes}}"
+        description: "require unique values for %{attributes}"
         expectations:
-          responds_to_scope: "{{subject_name}} instance responds to {{method}}"
-          is_unique: "{{subject_name}} to require unique values for {{attribute}}"
-          case_sensitive: "{{subject_name}} to {{not}}be case sensitive on {{attribute}} validation"
-          valid_with_new_scope: "{{subject_name}} to be valid when {{attribute}} scope ({{method}}) change"
+          responds_to_scope: "%{subject_name} instance responds to %{method}"
+          is_unique: "%{subject_name} to require unique values for %{attribute}"
+          case_sensitive: "%{subject_name} to %{not}be case sensitive on %{attribute} validation"
+          valid_with_new_scope: "%{subject_name} to be valid when %{attribute} scope (%{method}) change"
         optionals:
           scope:
-            positive: "scoped to {{sentence}}"
+            positive: "scoped to %{sentence}"
           case_sensitive:
             positive: "case sensitive"
             negative: "case insensitive"

--- a/remarkable_datamapper/lib/remarkable_datamapper/base.rb
+++ b/remarkable_datamapper/lib/remarkable_datamapper/base.rb
@@ -175,7 +175,7 @@ module Remarkable
         #   Using the underlying mechanism inside DataMapper makes us free from
         #   all those errors.
         #
-        # We replace {{count}} interpolation for 12345 which later is replaced
+        # We replace %{count} interpolation for 12345 which later is replaced
         # by a regexp which contains \d+.
         #
         def error_message_from_model(model, attribute, message) #:nodoc:

--- a/remarkable_datamapper/lib/remarkable_datamapper/describe.rb
+++ b/remarkable_datamapper/lib/remarkable_datamapper/describe.rb
@@ -33,7 +33,7 @@ module Remarkable
     #     remarkable:
     #       data_mapper:
     #         describe:
-    #           each: "{{key}} is {{value}}"
+    #           each: "%{key} is %{value}"
     #           prepend: "when "
     #           connector: " and "
     #
@@ -98,7 +98,7 @@ module Remarkable
         #     remarkable:
         #       data_mapper:
         #         describe:
-        #           each: "{{key}} is {{value}}"
+        #           each: "%{key} is %{value}"
         #           prepend: "when "
         #           connector: " and "
         #
@@ -126,7 +126,7 @@ module Remarkable
               end
 
               pieces << Remarkable.t("remarkable.data_mapper.describe.each",
-                                      :default => "{{key}} is {{value}}",
+                                      :default => "%{key} is %{value}",
                                       :key => translated_key.downcase, :value => value.inspect)
             end
 

--- a/remarkable_datamapper/locale/en.yml
+++ b/remarkable_datamapper/locale/en.yml
@@ -2,12 +2,12 @@ en:
   remarkable:
     data_mapper:
       describe:
-        each: "{{key}} is {{value}}"
+        each: "%{key} is %{value}"
         prepend: "when "
         connector: " and "
       expectations:
-        allow_nil: "{{subject_name}} to {{not}}allow nil values for {{attribute}}"
-        allow_blank: "{{subject_name}} to {{not}}allow blank values for {{attribute}}"
+        allow_nil: "%{subject_name} to %{not}allow nil values for %{attribute}"
+        allow_blank: "%{subject_name} to %{not}allow blank values for %{attribute}"
       optionals:
         allow_nil:
           positive: "allowing nil values"
@@ -17,71 +17,71 @@ en:
           negative: "not allowing blank values"
 
       accept_nested_attributes_for:
-        description: "accept nested attributes for {{associations}}"
+        description: "accept nested attributes for %{associations}"
         expectations:
-          association_exists: "{{subject_name}} to have association {{association}}, but does not"
-          is_autosave: "{{subject_name}} to have association {{association}} with autosave true, got false"
-          responds_to_attributes: "{{subject_name}} to respond to :{{association}}_attributes=, but does not"
-          allows_destroy: "{{subject_name}} with allow destroy equals to {{allow_destroy}}, got {{actual}}"
-          accepts: "{{subject_name}} to accept attributes {{attributes}} for {{association}}, but does not"
-          rejects: "{{subject_name}} to reject attributes {{attributes}} for {{association}}, but does not"
+          association_exists: "%{subject_name} to have association %{association}, but does not"
+          is_autosave: "%{subject_name} to have association %{association} with autosave true, got false"
+          responds_to_attributes: "%{subject_name} to respond to :%{association}_attributes=, but does not"
+          allows_destroy: "%{subject_name} with allow destroy equals to %{allow_destroy}, got %{actual}"
+          accepts: "%{subject_name} to accept attributes %{attributes} for %{association}, but does not"
+          rejects: "%{subject_name} to reject attributes %{attributes} for %{association}, but does not"
         optionals:
           allow_destroy:
             positive: "allowing destroy"
             negative: "not allowing destroy"
           accept:
-            positive: "accepting {{sentence}}"
+            positive: "accepting %{sentence}"
           reject:
-            positive: "rejecting {{sentence}}"
+            positive: "rejecting %{sentence}"
 
       allow_values_for:
-        description: "allow {{in}} as values for {{attributes}}"
+        description: "allow %{in} as values for %{attributes}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
 
       allow_mass_assignment_of:
-        description: "allow mass assignment of {{attributes}}"
+        description: "allow mass assignment of %{attributes}"
         expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} is protecting {{protected_attributes}})"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has not made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} is protecting %{protected_attributes})"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has not made %{attribute} accessible)"
         negative_expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} made {{accessible_attributes}} accessible)"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is not protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} made %{accessible_attributes} accessible)"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is not protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has made %{attribute} accessible)"
 
       association:
         belongs_to: belong to
         has_many: have many
         has_and_belongs_to_many: have and belong to many
         has_one: have one
-        description: "{{macro}} {{associations}}"
+        description: "%{macro} %{associations}"
         expectations:
-          association_exists: "{{subject_name}} records {{macro}} {{association}}, but the association does not exist"
-          macro_matches: "{{subject_name}} records {{macro}} {{association}}, got {{subject_name}} records {{actual_macro}} {{association}}"
-          through_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, through association does not exist"
-          source_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, source association does not exist"
-          klass_exists: "{{subject_name}} records {{macro}} {{association}}, but the association class does not exist"
-          join_table_exists: "join table {{join_table}} to exist, but does not"
-          foreign_key_exists: "foreign key {{foreign_key}} to exist on {{foreign_key_table}}, but does not"
-          polymorphic_exists: "{{subject_table}} to have {{polymorphic_column}} as column, but does not"
-          counter_cache_exists: "{{reflection_table}} to have {{counter_cache_column}} as column, but does not"
-          options_match: "{{subject_name}} records {{macro}} {{association}} with options {{options}}, got {{actual}}"
+          association_exists: "%{subject_name} records %{macro} %{association}, but the association does not exist"
+          macro_matches: "%{subject_name} records %{macro} %{association}, got %{subject_name} records %{actual_macro} %{association}"
+          through_exists: "%{subject_name} records %{macro} %{association} through %{through}, through association does not exist"
+          source_exists: "%{subject_name} records %{macro} %{association} through %{through}, source association does not exist"
+          klass_exists: "%{subject_name} records %{macro} %{association}, but the association class does not exist"
+          join_table_exists: "join table %{join_table} to exist, but does not"
+          foreign_key_exists: "foreign key %{foreign_key} to exist on %{foreign_key_table}, but does not"
+          polymorphic_exists: "%{subject_table} to have %{polymorphic_column} as column, but does not"
+          counter_cache_exists: "%{reflection_table} to have %{counter_cache_column} as column, but does not"
+          options_match: "%{subject_name} records %{macro} %{association} with options %{options}, got %{actual}"
         optionals:
           through:
-            positive: "through {{value}}"
+            positive: "through %{value}"
           source:
-            positive: "with source {{inspect}}"
+            positive: "with source %{inspect}"
           source_type:
-            positive: "with source type {{inspect}}"
+            positive: "with source type %{inspect}"
           class_name:
-            positive: "with class name {{inspect}}"
+            positive: "with class name %{inspect}"
           foreign_key:
-            positive: "with foreign key {{inspect}}"
+            positive: "with foreign key %{inspect}"
           dependent:
-            positive: "with dependent {{inspect}}"
+            positive: "with dependent %{inspect}"
           join_table:
-            positive: "with join table {{inspect}}"
+            positive: "with join table %{inspect}"
           uniq:
             positive: "with unique records"
             negative: "without unique records"
@@ -95,136 +95,136 @@ en:
             positive: "autosaving associated records"
             negative: "not autosaving associated records"
           as:
-            positive: "through the polymorphic interface {{inspect}}"
+            positive: "through the polymorphic interface %{inspect}"
           counter_cache:
-            positive: "with counter cache {{inspect}}"
+            positive: "with counter cache %{inspect}"
             negative: "without counter cache"
           select:
-            positive: "selecting {{inspect}}"
+            positive: "selecting %{inspect}"
           conditions:
-            positive: "with conditions {{inspect}}"
+            positive: "with conditions %{inspect}"
           include:
-            positive: "including {{inspect}}"
+            positive: "including %{inspect}"
           group:
-            positive: "grouping by {{inspect}}"
+            positive: "grouping by %{inspect}"
           having:
-            positive: "having {{inspect}}"
+            positive: "having %{inspect}"
           order:
-            positive: "with order {{inspect}}"
+            positive: "with order %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
           offset:
-            positive: "with offset {{inspect}}"
+            positive: "with offset %{inspect}"
 
       have_column:
-        description: "have column(s) named {{columns}}"
+        description: "have column(s) named %{columns}"
         expectations:
-          column_exists: "{{subject_name}} to have column named {{column}}"
-          options_match: "{{subject_name}} to have column {{column}} with options {{options}}, got {{actual}}"
+          column_exists: "%{subject_name} to have column named %{column}"
+          options_match: "%{subject_name} to have column %{column} with options %{options}, got %{actual}"
         optionals:
           type:
-            positive: "with type {{inspect}}"
+            positive: "with type %{inspect}"
           null:
             positive: "allowing null values"
             negative: "not allowing null values"
           default:
-            positive: "with default value {{inspect}}"
-            negative: "with default value {{inspect}}"
+            positive: "with default value %{inspect}"
+            negative: "with default value %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
 
       have_default_scope:
-        description: "have a default scope with {{options}}"
+        description: "have a default scope with %{options}"
         expectations:
-          options_match: "default scope with {{options}}, got {{actual}}"
+          options_match: "default scope with %{options}, got %{actual}"
 
       have_index:
-        description: "have index for column(s) {{columns}}"
+        description: "have index for column(s) %{columns}"
         expectations:
-          index_exists: "index {{column}} to exist on table {{table_name}}"
-          is_unique: "index on {{column}} with unique equals to {{unique}}, got {{actual}}"
+          index_exists: "index %{column} to exist on table %{table_name}"
+          is_unique: "index on %{column} with unique equals to %{unique}, got %{actual}"
         optionals:
           unique:
             positive: "with unique values"
             negative: "with non unique values"
           table_name:
-            positive: "on table {{value}}"
+            positive: "on table %{value}"
 
       have_readonly_attributes:
-        description: "make {{attributes}} read-only"
+        description: "make %{attributes} read-only"
         expectations:
-          is_readonly: "{{subject_name}} to make {{attribute}} read-only, got {{actual}}"
+          is_readonly: "%{subject_name} to make %{attribute} read-only, got %{actual}"
 
       have_scope:
-        description: "have to scope itself to {{options}} when {{scope_name}} is called"
+        description: "have to scope itself to %{options} when %{scope_name} is called"
         expectations:
-          is_scope: "{{scope_name}} when called on {{subject_name}} return an instance of ActiveRecord::NamedScope::Scope"
-          options_match: "{{scope_name}} when called on {{subject_name}} scope to {{options}}, got {{actual}}"
+          is_scope: "%{scope_name} when called on %{subject_name} return an instance of ActiveRecord::NamedScope::Scope"
+          options_match: "%{scope_name} when called on %{subject_name} scope to %{options}, got %{actual}"
         optionals:
           with:
-            positive: "with {{inspect}} as argument"
+            positive: "with %{inspect} as argument"
 
       validate_acceptance_of:
-        description: "require {{attributes}} to be accepted"
+        description: "require %{attributes} to be accepted"
         expectations:
-          requires_acceptance: "{{subject_name}} to be invalid if {{attribute}} is not accepted"
-          accept_is_valid: "{{subject_name}} to be valid when {{attribute}} is accepted with value {{accept}}"
+          requires_acceptance: "%{subject_name} to be invalid if %{attribute} is not accepted"
+          accept_is_valid: "%{subject_name} to be valid when %{attribute} is accepted with value %{accept}"
         optionals:
           accept:
-            positive: "with value {{inspect}}"
+            positive: "with value %{inspect}"
 
       validate_associated:
-        description: "require associated {{associations}} to be valid"
+        description: "require associated %{associations} to be valid"
         expectations:
-          is_valid: "{{subject_name}} to be invalid when {{association}} is invalid"
+          is_valid: "%{subject_name} to be invalid when %{association} is invalid"
 
       validate_confirmation_of:
-        description: "require {{attributes}} to be confirmed"
+        description: "require %{attributes} to be confirmed"
         expectations:
-          responds_to_confirmation: "{{subject_name}} instance responds to {{attribute}}_confirmation"
-          confirms: "{{subject_name}} to be valid only when {{attribute}} is confirmed"
+          responds_to_confirmation: "%{subject_name} instance responds to %{attribute}_confirmation"
+          confirms: "%{subject_name} to be valid only when %{attribute} is confirmed"
 
       validate_exclusion_of:
-        description: "ensure exclusion of {{attributes}} in {{in}}"
+        description: "ensure exclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_inclusion_of:
-        description: "ensure inclusion of {{attributes}} in {{in}}"
+        description: "ensure inclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_length_of:
-        description: "ensure length of {{attributes}}"
+        description: "ensure length of %{attributes}"
         expectations:
-          less_than_min_length: "{{subject_name}} to be invalid when {{attribute}} length is less than {{minimum}} characters"
-          exactly_min_length: "{{subject_name}} to be valid when {{attribute}} length is {{minimum}} characters"
-          more_than_max_length: "{{subject_name}} to be invalid when {{attribute}} length is more than {{maximum}} characters"
-          exactly_max_length: "{{subject_name}} to be valid when {{attribute}} length is {{maximum}} characters"
+          less_than_min_length: "%{subject_name} to be invalid when %{attribute} length is less than %{minimum} characters"
+          exactly_min_length: "%{subject_name} to be valid when %{attribute} length is %{minimum} characters"
+          more_than_max_length: "%{subject_name} to be invalid when %{attribute} length is more than %{maximum} characters"
+          exactly_max_length: "%{subject_name} to be valid when %{attribute} length is %{maximum} characters"
         optionals:
           within:
-            positive: "is within {{inspect}} characters"
+            positive: "is within %{inspect} characters"
           maximum:
-            positive: "is maximum {{inspect}} characters"
+            positive: "is maximum %{inspect} characters"
           minimum:
-            positive: "is minimum {{inspect}} characters"
+            positive: "is minimum %{inspect} characters"
           is:
-            positive: "is equal to {{inspect}} characters"
+            positive: "is equal to %{inspect} characters"
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       validate_numericality_of:
-        description: "ensure numericality of {{attributes}}"
+        description: "ensure numericality of %{attributes}"
         expectations:
-          only_numeric_values: "{{subject_name}} to allow only numeric values for {{attribute}}"
-          only_integer: "{{subject_name}} to {{not}}allow only integer values for {{attribute}}"
-          only_even: "{{subject_name}} to allow only even values for {{attribute}}"
-          only_odd: "{{subject_name}} to allow only odd values for {{attribute}}"
-          equals_to: "{{subject_name}} to be valid only when {{attribute}} is equal to {{count}}"
-          more_than_maximum: "{{subject_name}} to be invalid when {{attribute}} is greater than {{count}}"
-          less_than_minimum: "{{subject_name}} to be invalid when {{attribute}} is less than {{count}}"
+          only_numeric_values: "%{subject_name} to allow only numeric values for %{attribute}"
+          only_integer: "%{subject_name} to %{not}allow only integer values for %{attribute}"
+          only_even: "%{subject_name} to allow only even values for %{attribute}"
+          only_odd: "%{subject_name} to allow only odd values for %{attribute}"
+          equals_to: "%{subject_name} to be valid only when %{attribute} is equal to %{count}"
+          more_than_maximum: "%{subject_name} to be invalid when %{attribute} is greater than %{count}"
+          less_than_minimum: "%{subject_name} to be invalid when %{attribute} is less than %{count}"
         optionals:
           only_integer:
             positive: "allowing only integer values"
@@ -233,31 +233,31 @@ en:
           even:
             positive: "allowing only even values"
           equal_to:
-            positive: "is equal to {{inspect}}"
+            positive: "is equal to %{inspect}"
           less_than:
-            positive: "is less than {{inspect}}"
+            positive: "is less than %{inspect}"
           greater_than:
-            positive: "is greater than {{inspect}}"
+            positive: "is greater than %{inspect}"
           less_than_or_equal_to:
-            positive: "is less than or equal to {{inspect}}"
+            positive: "is less than or equal to %{inspect}"
           greater_than_or_equal_to:
-            positive: "is greater than or equal to {{inspect}}"
+            positive: "is greater than or equal to %{inspect}"
 
       validate_presence_of:
-        description: "require {{attributes}} to be set"
+        description: "require %{attributes} to be set"
         expectations:
-          allow_nil: "{{subject_name}} to require {{attribute}} to be set"
+          allow_nil: "%{subject_name} to require %{attribute} to be set"
 
       validate_is_unique:
-        description: "require unique values for {{attributes}}"
+        description: "require unique values for %{attributes}"
         expectations:
-          responds_to_scope: "{{subject_name}} instance responds to {{method}}"
-          is_unique: "{{subject_name}} to require unique values for {{attribute}}"
-          nullable: "{{subject_name}} to require {{attribute}} to be set"
-          case_sensitive: "{{subject_name}} to {{not}}be case sensitive on {{attribute}} validation"
-          valid_with_new_scope: "{{subject_name}} to be valid when {{attribute}} scope ({{method}}) change"
+          responds_to_scope: "%{subject_name} instance responds to %{method}"
+          is_unique: "%{subject_name} to require unique values for %{attribute}"
+          nullable: "%{subject_name} to require %{attribute} to be set"
+          case_sensitive: "%{subject_name} to %{not}be case sensitive on %{attribute} validation"
+          valid_with_new_scope: "%{subject_name} to be valid when %{attribute} scope (%{method}) change"
         optionals:
           scope:
-            positive: "scoped to {{sentence}}"
+            positive: "scoped to %{sentence}"
           nullable:
             positive: "allowing nil values"

--- a/remarkable_i18n/en.yml
+++ b/remarkable_i18n/en.yml
@@ -5,8 +5,8 @@ en:
       should: "should"
       should_not: "should not"
       example_disabled: "Example disabled"
-      failure_message_for_should: "Expected {{expectation}}"
-      failure_message_for_should_not: "Did not expect {{expectation}}"
+      failure_message_for_should: "Expected %{expectation}"
+      failure_message_for_should_not: "Did not expect %{expectation}"
 
       helpers:
         words_connector: ", "
@@ -14,121 +14,121 @@ en:
         last_word_connector: ", and "
 
     action_controller:
-      responding: "responding to #{{verb}} {{action}}"
-      mime_type: "with {{format}}"
+      responding: "responding to #%{verb} %{action}"
+      mime_type: "with %{format}"
 
       assign_to:
-        description: "assign {{names}}"
+        description: "assign %{names}"
         expectations:
-          assigned_value: "action to assign {{name}}, got no assignment"
-          is_kind_of: "assign {{name}} to be kind of {{with_kind_of}}, got a {{assign_class}}"
-          is_equal_value: "assign {{name}} to be equal to {{with}}, got {{assign_inspect}}"
+          assigned_value: "action to assign %{name}, got no assignment"
+          is_kind_of: "assign %{name} to be kind of %{with_kind_of}, got a %{assign_class}"
+          is_equal_value: "assign %{name} to be equal to %{with}, got %{assign_inspect}"
         optionals:
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       filter_params:
-        description: "filter {{params}} parameters from log"
+        description: "filter %{params} parameters from log"
         expectations:
           respond_to_filter_params: "controller to respond to filter_parameters (controller is not filtering any parameter)"
-          is_filtered: "{{param}} to be filtered, got no filtering"
+          is_filtered: "%{param} to be filtered, got no filtering"
 
       redirect_to:
-        description: "redirect to {{expected}}"
+        description: "redirect to %{expected}"
         expectations:
-          redirected: "redirect to {{expected}}, got no redirect"
-          status_matches: "redirect to {{expected}} with status {{with}}, got status {{status}}"
-          url_matches: "redirect to {{expected}}, got redirect to {{actual}}"
+          redirected: "redirect to %{expected}, got no redirect"
+          status_matches: "redirect to %{expected} with status %{with}, got status %{status}"
+          url_matches: "redirect to %{expected}, got redirect to %{actual}"
         optionals:
           with:
-            positive: "with status {{inspect}}"
+            positive: "with status %{inspect}"
 
       render_template:
         description: "render"
         expectations:
-          rendered: "template {{template}} to be rendered, got no render"
-          template_matches: "template {{template}} to be rendered, got {{actual_template}}"
-          layout_matches: "to render with layout {{layout}}, got {{actual_layout}}"
-          status_matches: "to render with status {{with}}, got {{actual_status}}"
-          body_matches: "to render with body {{body}}, got {{actual_body}}"
-          content_type_matches: "to render with content type {{content_type}}, got {{actual_content_type}}"
+          rendered: "template %{template} to be rendered, got no render"
+          template_matches: "template %{template} to be rendered, got %{actual_template}"
+          layout_matches: "to render with layout %{layout}, got %{actual_layout}"
+          status_matches: "to render with status %{with}, got %{actual_status}"
+          body_matches: "to render with body %{body}, got %{actual_body}"
+          content_type_matches: "to render with content type %{content_type}, got %{actual_content_type}"
         optionals:
           template:
-            positive: "template {{inspect}}"
+            positive: "template %{inspect}"
           layout:
-            positive: "with layout {{inspect}}"
+            positive: "with layout %{inspect}"
             negative: "with no layout"
           with:
-            positive: "with {{value}}"
+            positive: "with %{value}"
           body:
-            positive: "with body {{inspect}}"
+            positive: "with body %{inspect}"
           content_type:
-            positive: "with content type {{inspect}}"
+            positive: "with content type %{inspect}"
 
       respond_with:
         description: "respond"
         expectations:
-          status_matches: "to respond with status {{with}}, got {{actual_status}}"
-          body_matches: "to respond with body {{body}}, got {{actual_body}}"
-          content_type_matches: "to respond with content type {{content_type}}, got {{actual_content_type}}"
+          status_matches: "to respond with status %{with}, got %{actual_status}"
+          body_matches: "to respond with body %{body}, got %{actual_body}"
+          content_type_matches: "to respond with content type %{content_type}, got %{actual_content_type}"
         optionals:
           with:
-            positive: "with {{value}}"
+            positive: "with %{value}"
           body:
-            positive: "with body {{inspect}}"
+            positive: "with body %{inspect}"
           content_type:
-            positive: "with content type {{inspect}}"
+            positive: "with content type %{inspect}"
 
       route:
-        description: "route {{method}} {{path}} to/from {{options}}"
+        description: "route %{method} %{path} to/from %{options}"
         expectations:
-          map_to_path: "to map {{options}} to {{method}} {{path}}, got {{actual}}"
-          generate_params: "to generate params {{options}} from {{method}} {{path}}, got {{actual}}"
+          map_to_path: "to map %{options} to %{method} %{path}, got %{actual}"
+          generate_params: "to generate params %{options} from %{method} %{path}, got %{actual}"
 
       set_cookies:
-        description: "set cookies {{keys}}"
+        description: "set cookies %{keys}"
         expectations:
-          is_not_empty: "any cookie to be set, got {{cookies_inspect}}"
-          contains_value: "any cookie to be set to {{to}}, got {{cookies_inspect}}"
-          assigned_value: "cookie {{key}} to be set, got {{cookies_inspect}}"
-          is_equal_value: "cookie {{key}} to be set to {{to}}, got {{cookies_inspect}}"
+          is_not_empty: "any cookie to be set, got %{cookies_inspect}"
+          contains_value: "any cookie to be set to %{to}, got %{cookies_inspect}"
+          assigned_value: "cookie %{key} to be set, got %{cookies_inspect}"
+          is_equal_value: "cookie %{key} to be set to %{to}, got %{cookies_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 
       set_session:
-        description: "set session variable {{keys}}"
+        description: "set session variable %{keys}"
         expectations:
-          is_not_empty: "any session variable to be set, got {{session_inspect}}"
-          contains_value: "any session variable to be set to {{to}}, got {{session_inspect}}"
-          assigned_value: "session variable {{key}} to be set, got {{session_inspect}}"
-          is_equal_value: "session variable {{key}} to be set to {{to}}, got {{session_inspect}}"
+          is_not_empty: "any session variable to be set, got %{session_inspect}"
+          contains_value: "any session variable to be set to %{to}, got %{session_inspect}"
+          assigned_value: "session variable %{key} to be set, got %{session_inspect}"
+          is_equal_value: "session variable %{key} to be set to %{to}, got %{session_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 
       set_the_flash:
-        description: "set the flash message {{keys}}"
+        description: "set the flash message %{keys}"
         expectations:
-          is_not_empty: "any flash message to be set, got {{flash_inspect}}"
-          contains_value: "any flash message to be set to {{to}}, got {{flash_inspect}}"
-          assigned_value: "flash message {{key}} to be set, got {{flash_inspect}}"
-          is_equal_value: "flash message {{key}} to be set to {{to}}, got {{flash_inspect}}"
+          is_not_empty: "any flash message to be set, got %{flash_inspect}"
+          contains_value: "any flash message to be set to %{to}, got %{flash_inspect}"
+          assigned_value: "flash message %{key} to be set, got %{flash_inspect}"
+          is_equal_value: "flash message %{key} to be set to %{to}, got %{flash_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 
     active_record:
       describe:
-        each: "{{key}} is {{value}}"
+        each: "%{key} is %{value}"
         prepend: "when "
         connector: " and "
       expectations:
-        allow_nil: "{{subject_name}} to {{not}}allow nil values for {{attribute}}"
-        allow_blank: "{{subject_name}} to {{not}}allow blank values for {{attribute}}"
+        allow_nil: "%{subject_name} to %{not}allow nil values for %{attribute}"
+        allow_blank: "%{subject_name} to %{not}allow blank values for %{attribute}"
       optionals:
         allow_nil:
           positive: "allowing nil values"
@@ -138,71 +138,71 @@ en:
           negative: "not allowing blank values"
 
       accept_nested_attributes_for:
-        description: "accept nested attributes for {{associations}}"
+        description: "accept nested attributes for %{associations}"
         expectations:
-          association_exists: "{{subject_name}} to have association {{association}}, but does not"
-          is_autosave: "{{subject_name}} to have association {{association}} with autosave true, got false"
-          responds_to_attributes: "{{subject_name}} to respond to :{{association}}_attributes=, but does not"
-          allows_destroy: "{{subject_name}} with allow destroy equals to {{allow_destroy}}, got {{actual}}"
-          accepts: "{{subject_name}} to accept attributes {{attributes}} for {{association}}, but does not"
-          rejects: "{{subject_name}} to reject attributes {{attributes}} for {{association}}, but does not"
+          association_exists: "%{subject_name} to have association %{association}, but does not"
+          is_autosave: "%{subject_name} to have association %{association} with autosave true, got false"
+          responds_to_attributes: "%{subject_name} to respond to :%{association}_attributes=, but does not"
+          allows_destroy: "%{subject_name} with allow destroy equals to %{allow_destroy}, got %{actual}"
+          accepts: "%{subject_name} to accept attributes %{attributes} for %{association}, but does not"
+          rejects: "%{subject_name} to reject attributes %{attributes} for %{association}, but does not"
         optionals:
           allow_destroy:
             positive: "allowing destroy"
             negative: "not allowing destroy"
           accept:
-            positive: "accepting {{sentence}}"
+            positive: "accepting %{sentence}"
           reject:
-            positive: "rejecting {{sentence}}"
+            positive: "rejecting %{sentence}"
 
       allow_values_for:
-        description: "allow {{in}} as values for {{attributes}}"
+        description: "allow %{in} as values for %{attributes}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
 
       allow_mass_assignment_of:
-        description: "allow mass assignment of {{attributes}}"
+        description: "allow mass assignment of %{attributes}"
         expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} is protecting {{protected_attributes}})"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has not made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} is protecting %{protected_attributes})"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has not made %{attribute} accessible)"
         negative_expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} made {{accessible_attributes}} accessible)"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is not protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} made %{accessible_attributes} accessible)"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is not protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has made %{attribute} accessible)"
 
       association:
         belongs_to: belong to
         has_many: have many
         has_and_belongs_to_many: have and belong to many
         has_one: have one
-        description: "{{macro}} {{associations}}"
+        description: "%{macro} %{associations}"
         expectations:
-          association_exists: "{{subject_name}} records {{macro}} {{association}}, but the association does not exist"
-          macro_matches: "{{subject_name}} records {{macro}} {{association}}, got {{subject_name}} records {{actual_macro}} {{association}}"
-          through_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, through association does not exist"
-          source_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, source association does not exist"
-          klass_exists: "{{subject_name}} records {{macro}} {{association}}, but the association class does not exist"
-          join_table_exists: "join table {{join_table}} to exist, but does not"
-          foreign_key_exists: "foreign key {{foreign_key}} to exist on {{foreign_key_table}}, but does not"
-          polymorphic_exists: "{{subject_table}} to have {{polymorphic_column}} as column, but does not"
-          counter_cache_exists: "{{reflection_table}} to have {{counter_cache_column}} as column, but does not"
-          options_match: "{{subject_name}} records {{macro}} {{association}} with options {{options}}, got {{actual}}"
+          association_exists: "%{subject_name} records %{macro} %{association}, but the association does not exist"
+          macro_matches: "%{subject_name} records %{macro} %{association}, got %{subject_name} records %{actual_macro} %{association}"
+          through_exists: "%{subject_name} records %{macro} %{association} through %{through}, through association does not exist"
+          source_exists: "%{subject_name} records %{macro} %{association} through %{through}, source association does not exist"
+          klass_exists: "%{subject_name} records %{macro} %{association}, but the association class does not exist"
+          join_table_exists: "join table %{join_table} to exist, but does not"
+          foreign_key_exists: "foreign key %{foreign_key} to exist on %{foreign_key_table}, but does not"
+          polymorphic_exists: "%{subject_table} to have %{polymorphic_column} as column, but does not"
+          counter_cache_exists: "%{reflection_table} to have %{counter_cache_column} as column, but does not"
+          options_match: "%{subject_name} records %{macro} %{association} with options %{options}, got %{actual}"
         optionals:
           through:
-            positive: "through {{value}}"
+            positive: "through %{value}"
           source:
-            positive: "with source {{inspect}}"
+            positive: "with source %{inspect}"
           source_type:
-            positive: "with source type {{inspect}}"
+            positive: "with source type %{inspect}"
           class_name:
-            positive: "with class name {{inspect}}"
+            positive: "with class name %{inspect}"
           foreign_key:
-            positive: "with foreign key {{inspect}}"
+            positive: "with foreign key %{inspect}"
           dependent:
-            positive: "with dependent {{inspect}}"
+            positive: "with dependent %{inspect}"
           join_table:
-            positive: "with join table {{inspect}}"
+            positive: "with join table %{inspect}"
           uniq:
             positive: "with unique records"
             negative: "without unique records"
@@ -216,136 +216,136 @@ en:
             positive: "autosaving associated records"
             negative: "not autosaving associated records"
           as:
-            positive: "through the polymorphic interface {{inspect}}"
+            positive: "through the polymorphic interface %{inspect}"
           counter_cache:
-            positive: "with counter cache {{inspect}}"
+            positive: "with counter cache %{inspect}"
             negative: "without counter cache"
           select:
-            positive: "selecting {{inspect}}"
+            positive: "selecting %{inspect}"
           conditions:
-            positive: "with conditions {{inspect}}"
+            positive: "with conditions %{inspect}"
           include:
-            positive: "including {{inspect}}"
+            positive: "including %{inspect}"
           group:
-            positive: "grouping by {{inspect}}"
+            positive: "grouping by %{inspect}"
           having:
-            positive: "having {{inspect}}"
+            positive: "having %{inspect}"
           order:
-            positive: "with order {{inspect}}"
+            positive: "with order %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
           offset:
-            positive: "with offset {{inspect}}"
+            positive: "with offset %{inspect}"
 
       have_column:
-        description: "have column(s) named {{columns}}"
+        description: "have column(s) named %{columns}"
         expectations:
-          column_exists: "{{subject_name}} to have column named {{column}}"
-          options_match: "{{subject_name}} to have column {{column}} with options {{options}}, got {{actual}}"
+          column_exists: "%{subject_name} to have column named %{column}"
+          options_match: "%{subject_name} to have column %{column} with options %{options}, got %{actual}"
         optionals:
           type:
-            positive: "with type {{inspect}}"
+            positive: "with type %{inspect}"
           null:
             positive: "allowing null values"
             negative: "not allowing null values"
           default:
-            positive: "with default value {{inspect}}"
-            negative: "with default value {{inspect}}"
+            positive: "with default value %{inspect}"
+            negative: "with default value %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
 
       have_default_scope:
-        description: "have a default scope with {{options}}"
+        description: "have a default scope with %{options}"
         expectations:
-          options_match: "default scope with {{options}}, got {{actual}}"
+          options_match: "default scope with %{options}, got %{actual}"
 
       have_index:
-        description: "have index for column(s) {{columns}}"
+        description: "have index for column(s) %{columns}"
         expectations:
-          index_exists: "index {{column}} to exist on table {{table_name}}"
-          is_unique: "index on {{column}} with unique equals to {{unique}}, got {{actual}}"
+          index_exists: "index %{column} to exist on table %{table_name}"
+          is_unique: "index on %{column} with unique equals to %{unique}, got %{actual}"
         optionals:
           unique:
             positive: "with unique values"
             negative: "with non unique values"
           table_name:
-            positive: "on table {{value}}"
+            positive: "on table %{value}"
 
       have_readonly_attributes:
-        description: "make {{attributes}} read-only"
+        description: "make %{attributes} read-only"
         expectations:
-          is_readonly: "{{subject_name}} to make {{attribute}} read-only, got {{actual}}"
+          is_readonly: "%{subject_name} to make %{attribute} read-only, got %{actual}"
 
       have_scope:
-        description: "have to scope itself to {{options}} when {{scope_name}} is called"
+        description: "have to scope itself to %{options} when %{scope_name} is called"
         expectations:
-          is_scope: "{{scope_name}} when called on {{subject_name}} return an instance of ActiveRecord::NamedScope::Scope"
-          options_match: "{{scope_name}} when called on {{subject_name}} scope to {{options}}, got {{actual}}"
+          is_scope: "%{scope_name} when called on %{subject_name} return an instance of ActiveRecord::NamedScope::Scope"
+          options_match: "%{scope_name} when called on %{subject_name} scope to %{options}, got %{actual}"
         optionals:
           with:
-            positive: "with {{inspect}} as argument"
+            positive: "with %{inspect} as argument"
 
       validate_acceptance_of:
-        description: "require {{attributes}} to be accepted"
+        description: "require %{attributes} to be accepted"
         expectations:
-          requires_acceptance: "{{subject_name}} to be invalid if {{attribute}} is not accepted"
-          accept_is_valid: "{{subject_name}} to be valid when {{attribute}} is accepted with value {{accept}}"
+          requires_acceptance: "%{subject_name} to be invalid if %{attribute} is not accepted"
+          accept_is_valid: "%{subject_name} to be valid when %{attribute} is accepted with value %{accept}"
         optionals:
           accept:
-            positive: "with value {{inspect}}"
+            positive: "with value %{inspect}"
 
       validate_associated:
-        description: "require associated {{associations}} to be valid"
+        description: "require associated %{associations} to be valid"
         expectations:
-          is_valid: "{{subject_name}} to be invalid when {{association}} is invalid"
+          is_valid: "%{subject_name} to be invalid when %{association} is invalid"
 
       validate_confirmation_of:
-        description: "require {{attributes}} to be confirmed"
+        description: "require %{attributes} to be confirmed"
         expectations:
-          responds_to_confirmation: "{{subject_name}} instance responds to {{attribute}}_confirmation"
-          confirms: "{{subject_name}} to be valid only when {{attribute}} is confirmed"
+          responds_to_confirmation: "%{subject_name} instance responds to %{attribute}_confirmation"
+          confirms: "%{subject_name} to be valid only when %{attribute} is confirmed"
 
       validate_exclusion_of:
-        description: "ensure exclusion of {{attributes}} in {{in}}"
+        description: "ensure exclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_inclusion_of:
-        description: "ensure inclusion of {{attributes}} in {{in}}"
+        description: "ensure inclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_length_of:
-        description: "ensure length of {{attributes}}"
+        description: "ensure length of %{attributes}"
         expectations:
-          less_than_min_length: "{{subject_name}} to be invalid when {{attribute}} length is less than {{minimum}} characters"
-          exactly_min_length: "{{subject_name}} to be valid when {{attribute}} length is {{minimum}} characters"
-          more_than_max_length: "{{subject_name}} to be invalid when {{attribute}} length is more than {{maximum}} characters"
-          exactly_max_length: "{{subject_name}} to be valid when {{attribute}} length is {{maximum}} characters"
+          less_than_min_length: "%{subject_name} to be invalid when %{attribute} length is less than %{minimum} characters"
+          exactly_min_length: "%{subject_name} to be valid when %{attribute} length is %{minimum} characters"
+          more_than_max_length: "%{subject_name} to be invalid when %{attribute} length is more than %{maximum} characters"
+          exactly_max_length: "%{subject_name} to be valid when %{attribute} length is %{maximum} characters"
         optionals:
           within:
-            positive: "is within {{inspect}} characters"
+            positive: "is within %{inspect} characters"
           maximum:
-            positive: "is maximum {{inspect}} characters"
+            positive: "is maximum %{inspect} characters"
           minimum:
-            positive: "is minimum {{inspect}} characters"
+            positive: "is minimum %{inspect} characters"
           is:
-            positive: "is equal to {{inspect}} characters"
+            positive: "is equal to %{inspect} characters"
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       validate_numericality_of:
-        description: "ensure numericality of {{attributes}}"
+        description: "ensure numericality of %{attributes}"
         expectations:
-          only_numeric_values: "{{subject_name}} to allow only numeric values for {{attribute}}"
-          only_integer: "{{subject_name}} to {{not}}allow only integer values for {{attribute}}"
-          only_even: "{{subject_name}} to allow only even values for {{attribute}}"
-          only_odd: "{{subject_name}} to allow only odd values for {{attribute}}"
-          equals_to: "{{subject_name}} to be valid only when {{attribute}} is equal to {{count}}"
-          more_than_maximum: "{{subject_name}} to be invalid when {{attribute}} is greater than {{count}}"
-          less_than_minimum: "{{subject_name}} to be invalid when {{attribute}} is less than {{count}}"
+          only_numeric_values: "%{subject_name} to allow only numeric values for %{attribute}"
+          only_integer: "%{subject_name} to %{not}allow only integer values for %{attribute}"
+          only_even: "%{subject_name} to allow only even values for %{attribute}"
+          only_odd: "%{subject_name} to allow only odd values for %{attribute}"
+          equals_to: "%{subject_name} to be valid only when %{attribute} is equal to %{count}"
+          more_than_maximum: "%{subject_name} to be invalid when %{attribute} is greater than %{count}"
+          less_than_minimum: "%{subject_name} to be invalid when %{attribute} is less than %{count}"
         optionals:
           only_integer:
             positive: "allowing only integer values"
@@ -354,43 +354,43 @@ en:
           even:
             positive: "allowing only even values"
           equal_to:
-            positive: "is equal to {{inspect}}"
+            positive: "is equal to %{inspect}"
           less_than:
-            positive: "is less than {{inspect}}"
+            positive: "is less than %{inspect}"
           greater_than:
-            positive: "is greater than {{inspect}}"
+            positive: "is greater than %{inspect}"
           less_than_or_equal_to:
-            positive: "is less than or equal to {{inspect}}"
+            positive: "is less than or equal to %{inspect}"
           greater_than_or_equal_to:
-            positive: "is greater than or equal to {{inspect}}"
+            positive: "is greater than or equal to %{inspect}"
 
       validate_presence_of:
-        description: "require {{attributes}} to be set"
+        description: "require %{attributes} to be set"
         expectations:
-          allow_nil: "{{subject_name}} to require {{attribute}} to be set"
+          allow_nil: "%{subject_name} to require %{attribute} to be set"
 
       validate_uniqueness_of:
-        description: "require unique values for {{attributes}}"
+        description: "require unique values for %{attributes}"
         expectations:
-          responds_to_scope: "{{subject_name}} instance responds to {{method}}"
-          is_unique: "{{subject_name}} to require unique values for {{attribute}}"
-          case_sensitive: "{{subject_name}} to {{not}}be case sensitive on {{attribute}} validation"
-          valid_with_new_scope: "{{subject_name}} to be valid when {{attribute}} scope ({{method}}) change"
+          responds_to_scope: "%{subject_name} instance responds to %{method}"
+          is_unique: "%{subject_name} to require unique values for %{attribute}"
+          case_sensitive: "%{subject_name} to %{not}be case sensitive on %{attribute} validation"
+          valid_with_new_scope: "%{subject_name} to be valid when %{attribute} scope (%{method}) change"
         optionals:
           scope:
-            positive: "scoped to {{sentence}}"
+            positive: "scoped to %{sentence}"
           case_sensitive:
             positive: "case sensitive"
             negative: "case insensitive"
 
     data_mapper:
       describe:
-        each: "{{key}} is {{value}}"
+        each: "%{key} is %{value}"
         prepend: "when "
         connector: " and "
       expectations:
-        allow_nil: "{{subject_name}} to {{not}}allow nil values for {{attribute}}"
-        allow_blank: "{{subject_name}} to {{not}}allow blank values for {{attribute}}"
+        allow_nil: "%{subject_name} to %{not}allow nil values for %{attribute}"
+        allow_blank: "%{subject_name} to %{not}allow blank values for %{attribute}"
       optionals:
         allow_nil:
           positive: "allowing nil values"
@@ -400,71 +400,71 @@ en:
           negative: "not allowing blank values"
 
       accept_nested_attributes_for:
-        description: "accept nested attributes for {{associations}}"
+        description: "accept nested attributes for %{associations}"
         expectations:
-          association_exists: "{{subject_name}} to have association {{association}}, but does not"
-          is_autosave: "{{subject_name}} to have association {{association}} with autosave true, got false"
-          responds_to_attributes: "{{subject_name}} to respond to :{{association}}_attributes=, but does not"
-          allows_destroy: "{{subject_name}} with allow destroy equals to {{allow_destroy}}, got {{actual}}"
-          accepts: "{{subject_name}} to accept attributes {{attributes}} for {{association}}, but does not"
-          rejects: "{{subject_name}} to reject attributes {{attributes}} for {{association}}, but does not"
+          association_exists: "%{subject_name} to have association %{association}, but does not"
+          is_autosave: "%{subject_name} to have association %{association} with autosave true, got false"
+          responds_to_attributes: "%{subject_name} to respond to :%{association}_attributes=, but does not"
+          allows_destroy: "%{subject_name} with allow destroy equals to %{allow_destroy}, got %{actual}"
+          accepts: "%{subject_name} to accept attributes %{attributes} for %{association}, but does not"
+          rejects: "%{subject_name} to reject attributes %{attributes} for %{association}, but does not"
         optionals:
           allow_destroy:
             positive: "allowing destroy"
             negative: "not allowing destroy"
           accept:
-            positive: "accepting {{sentence}}"
+            positive: "accepting %{sentence}"
           reject:
-            positive: "rejecting {{sentence}}"
+            positive: "rejecting %{sentence}"
 
       allow_values_for:
-        description: "allow {{in}} as values for {{attributes}}"
+        description: "allow %{in} as values for %{attributes}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
 
       allow_mass_assignment_of:
-        description: "allow mass assignment of {{attributes}}"
+        description: "allow mass assignment of %{attributes}"
         expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} is protecting {{protected_attributes}})"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has not made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} is protecting %{protected_attributes})"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has not made %{attribute} accessible)"
         negative_expectations:
-          allows: "{{subject_name}} to allow mass assignment ({{subject_name}} made {{accessible_attributes}} accessible)"
-          is_protected: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} is not protecting {{attribute}})"
-          is_accessible: "{{subject_name}} to allow mass assignment of {{attribute}} ({{subject_name}} has made {{attribute}} accessible)"
+          allows: "%{subject_name} to allow mass assignment (%{subject_name} made %{accessible_attributes} accessible)"
+          is_protected: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} is not protecting %{attribute})"
+          is_accessible: "%{subject_name} to allow mass assignment of %{attribute} (%{subject_name} has made %{attribute} accessible)"
 
       association:
         belongs_to: belong to
         has_many: have many
         has_and_belongs_to_many: have and belong to many
         has_one: have one
-        description: "{{macro}} {{associations}}"
+        description: "%{macro} %{associations}"
         expectations:
-          association_exists: "{{subject_name}} records {{macro}} {{association}}, but the association does not exist"
-          macro_matches: "{{subject_name}} records {{macro}} {{association}}, got {{subject_name}} records {{actual_macro}} {{association}}"
-          through_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, through association does not exist"
-          source_exists: "{{subject_name}} records {{macro}} {{association}} through {{through}}, source association does not exist"
-          klass_exists: "{{subject_name}} records {{macro}} {{association}}, but the association class does not exist"
-          join_table_exists: "join table {{join_table}} to exist, but does not"
-          foreign_key_exists: "foreign key {{foreign_key}} to exist on {{foreign_key_table}}, but does not"
-          polymorphic_exists: "{{subject_table}} to have {{polymorphic_column}} as column, but does not"
-          counter_cache_exists: "{{reflection_table}} to have {{counter_cache_column}} as column, but does not"
-          options_match: "{{subject_name}} records {{macro}} {{association}} with options {{options}}, got {{actual}}"
+          association_exists: "%{subject_name} records %{macro} %{association}, but the association does not exist"
+          macro_matches: "%{subject_name} records %{macro} %{association}, got %{subject_name} records %{actual_macro} %{association}"
+          through_exists: "%{subject_name} records %{macro} %{association} through %{through}, through association does not exist"
+          source_exists: "%{subject_name} records %{macro} %{association} through %{through}, source association does not exist"
+          klass_exists: "%{subject_name} records %{macro} %{association}, but the association class does not exist"
+          join_table_exists: "join table %{join_table} to exist, but does not"
+          foreign_key_exists: "foreign key %{foreign_key} to exist on %{foreign_key_table}, but does not"
+          polymorphic_exists: "%{subject_table} to have %{polymorphic_column} as column, but does not"
+          counter_cache_exists: "%{reflection_table} to have %{counter_cache_column} as column, but does not"
+          options_match: "%{subject_name} records %{macro} %{association} with options %{options}, got %{actual}"
         optionals:
           through:
-            positive: "through {{value}}"
+            positive: "through %{value}"
           source:
-            positive: "with source {{inspect}}"
+            positive: "with source %{inspect}"
           source_type:
-            positive: "with source type {{inspect}}"
+            positive: "with source type %{inspect}"
           class_name:
-            positive: "with class name {{inspect}}"
+            positive: "with class name %{inspect}"
           foreign_key:
-            positive: "with foreign key {{inspect}}"
+            positive: "with foreign key %{inspect}"
           dependent:
-            positive: "with dependent {{inspect}}"
+            positive: "with dependent %{inspect}"
           join_table:
-            positive: "with join table {{inspect}}"
+            positive: "with join table %{inspect}"
           uniq:
             positive: "with unique records"
             negative: "without unique records"
@@ -478,136 +478,136 @@ en:
             positive: "autosaving associated records"
             negative: "not autosaving associated records"
           as:
-            positive: "through the polymorphic interface {{inspect}}"
+            positive: "through the polymorphic interface %{inspect}"
           counter_cache:
-            positive: "with counter cache {{inspect}}"
+            positive: "with counter cache %{inspect}"
             negative: "without counter cache"
           select:
-            positive: "selecting {{inspect}}"
+            positive: "selecting %{inspect}"
           conditions:
-            positive: "with conditions {{inspect}}"
+            positive: "with conditions %{inspect}"
           include:
-            positive: "including {{inspect}}"
+            positive: "including %{inspect}"
           group:
-            positive: "grouping by {{inspect}}"
+            positive: "grouping by %{inspect}"
           having:
-            positive: "having {{inspect}}"
+            positive: "having %{inspect}"
           order:
-            positive: "with order {{inspect}}"
+            positive: "with order %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
           offset:
-            positive: "with offset {{inspect}}"
+            positive: "with offset %{inspect}"
 
       have_column:
-        description: "have column(s) named {{columns}}"
+        description: "have column(s) named %{columns}"
         expectations:
-          column_exists: "{{subject_name}} to have column named {{column}}"
-          options_match: "{{subject_name}} to have column {{column}} with options {{options}}, got {{actual}}"
+          column_exists: "%{subject_name} to have column named %{column}"
+          options_match: "%{subject_name} to have column %{column} with options %{options}, got %{actual}"
         optionals:
           type:
-            positive: "with type {{inspect}}"
+            positive: "with type %{inspect}"
           null:
             positive: "allowing null values"
             negative: "not allowing null values"
           default:
-            positive: "with default value {{inspect}}"
-            negative: "with default value {{inspect}}"
+            positive: "with default value %{inspect}"
+            negative: "with default value %{inspect}"
           limit:
-            positive: "with limit {{inspect}}"
+            positive: "with limit %{inspect}"
 
       have_default_scope:
-        description: "have a default scope with {{options}}"
+        description: "have a default scope with %{options}"
         expectations:
-          options_match: "default scope with {{options}}, got {{actual}}"
+          options_match: "default scope with %{options}, got %{actual}"
 
       have_index:
-        description: "have index for column(s) {{columns}}"
+        description: "have index for column(s) %{columns}"
         expectations:
-          index_exists: "index {{column}} to exist on table {{table_name}}"
-          is_unique: "index on {{column}} with unique equals to {{unique}}, got {{actual}}"
+          index_exists: "index %{column} to exist on table %{table_name}"
+          is_unique: "index on %{column} with unique equals to %{unique}, got %{actual}"
         optionals:
           unique:
             positive: "with unique values"
             negative: "with non unique values"
           table_name:
-            positive: "on table {{value}}"
+            positive: "on table %{value}"
 
       have_readonly_attributes:
-        description: "make {{attributes}} read-only"
+        description: "make %{attributes} read-only"
         expectations:
-          is_readonly: "{{subject_name}} to make {{attribute}} read-only, got {{actual}}"
+          is_readonly: "%{subject_name} to make %{attribute} read-only, got %{actual}"
 
       have_scope:
-        description: "have to scope itself to {{options}} when {{scope_name}} is called"
+        description: "have to scope itself to %{options} when %{scope_name} is called"
         expectations:
-          is_scope: "{{scope_name}} when called on {{subject_name}} return an instance of ActiveRecord::NamedScope::Scope"
-          options_match: "{{scope_name}} when called on {{subject_name}} scope to {{options}}, got {{actual}}"
+          is_scope: "%{scope_name} when called on %{subject_name} return an instance of ActiveRecord::NamedScope::Scope"
+          options_match: "%{scope_name} when called on %{subject_name} scope to %{options}, got %{actual}"
         optionals:
           with:
-            positive: "with {{inspect}} as argument"
+            positive: "with %{inspect} as argument"
 
       validate_acceptance_of:
-        description: "require {{attributes}} to be accepted"
+        description: "require %{attributes} to be accepted"
         expectations:
-          requires_acceptance: "{{subject_name}} to be invalid if {{attribute}} is not accepted"
-          accept_is_valid: "{{subject_name}} to be valid when {{attribute}} is accepted with value {{accept}}"
+          requires_acceptance: "%{subject_name} to be invalid if %{attribute} is not accepted"
+          accept_is_valid: "%{subject_name} to be valid when %{attribute} is accepted with value %{accept}"
         optionals:
           accept:
-            positive: "with value {{inspect}}"
+            positive: "with value %{inspect}"
 
       validate_associated:
-        description: "require associated {{associations}} to be valid"
+        description: "require associated %{associations} to be valid"
         expectations:
-          is_valid: "{{subject_name}} to be invalid when {{association}} is invalid"
+          is_valid: "%{subject_name} to be invalid when %{association} is invalid"
 
       validate_confirmation_of:
-        description: "require {{attributes}} to be confirmed"
+        description: "require %{attributes} to be confirmed"
         expectations:
-          responds_to_confirmation: "{{subject_name}} instance responds to {{attribute}}_confirmation"
-          confirms: "{{subject_name}} to be valid only when {{attribute}} is confirmed"
+          responds_to_confirmation: "%{subject_name} instance responds to %{attribute}_confirmation"
+          confirms: "%{subject_name} to be valid only when %{attribute} is confirmed"
 
       validate_exclusion_of:
-        description: "ensure exclusion of {{attributes}} in {{in}}"
+        description: "ensure exclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_inclusion_of:
-        description: "ensure inclusion of {{attributes}} in {{in}}"
+        description: "ensure inclusion of %{attributes} in %{in}"
         expectations:
-          is_valid: "{{subject_name}} to be valid when {{attribute}} is set to {{value}}"
-          is_invalid: "{{subject_name}} to be invalid when {{attribute}} is set to {{value}}"
+          is_valid: "%{subject_name} to be valid when %{attribute} is set to %{value}"
+          is_invalid: "%{subject_name} to be invalid when %{attribute} is set to %{value}"
 
       validate_length_of:
-        description: "ensure length of {{attributes}}"
+        description: "ensure length of %{attributes}"
         expectations:
-          less_than_min_length: "{{subject_name}} to be invalid when {{attribute}} length is less than {{minimum}} characters"
-          exactly_min_length: "{{subject_name}} to be valid when {{attribute}} length is {{minimum}} characters"
-          more_than_max_length: "{{subject_name}} to be invalid when {{attribute}} length is more than {{maximum}} characters"
-          exactly_max_length: "{{subject_name}} to be valid when {{attribute}} length is {{maximum}} characters"
+          less_than_min_length: "%{subject_name} to be invalid when %{attribute} length is less than %{minimum} characters"
+          exactly_min_length: "%{subject_name} to be valid when %{attribute} length is %{minimum} characters"
+          more_than_max_length: "%{subject_name} to be invalid when %{attribute} length is more than %{maximum} characters"
+          exactly_max_length: "%{subject_name} to be valid when %{attribute} length is %{maximum} characters"
         optionals:
           within:
-            positive: "is within {{inspect}} characters"
+            positive: "is within %{inspect} characters"
           maximum:
-            positive: "is maximum {{inspect}} characters"
+            positive: "is maximum %{inspect} characters"
           minimum:
-            positive: "is minimum {{inspect}} characters"
+            positive: "is minimum %{inspect} characters"
           is:
-            positive: "is equal to {{inspect}} characters"
+            positive: "is equal to %{inspect} characters"
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       validate_numericality_of:
-        description: "ensure numericality of {{attributes}}"
+        description: "ensure numericality of %{attributes}"
         expectations:
-          only_numeric_values: "{{subject_name}} to allow only numeric values for {{attribute}}"
-          only_integer: "{{subject_name}} to {{not}}allow only integer values for {{attribute}}"
-          only_even: "{{subject_name}} to allow only even values for {{attribute}}"
-          only_odd: "{{subject_name}} to allow only odd values for {{attribute}}"
-          equals_to: "{{subject_name}} to be valid only when {{attribute}} is equal to {{count}}"
-          more_than_maximum: "{{subject_name}} to be invalid when {{attribute}} is greater than {{count}}"
-          less_than_minimum: "{{subject_name}} to be invalid when {{attribute}} is less than {{count}}"
+          only_numeric_values: "%{subject_name} to allow only numeric values for %{attribute}"
+          only_integer: "%{subject_name} to %{not}allow only integer values for %{attribute}"
+          only_even: "%{subject_name} to allow only even values for %{attribute}"
+          only_odd: "%{subject_name} to allow only odd values for %{attribute}"
+          equals_to: "%{subject_name} to be valid only when %{attribute} is equal to %{count}"
+          more_than_maximum: "%{subject_name} to be invalid when %{attribute} is greater than %{count}"
+          less_than_minimum: "%{subject_name} to be invalid when %{attribute} is less than %{count}"
         optionals:
           only_integer:
             positive: "allowing only integer values"
@@ -616,31 +616,31 @@ en:
           even:
             positive: "allowing only even values"
           equal_to:
-            positive: "is equal to {{inspect}}"
+            positive: "is equal to %{inspect}"
           less_than:
-            positive: "is less than {{inspect}}"
+            positive: "is less than %{inspect}"
           greater_than:
-            positive: "is greater than {{inspect}}"
+            positive: "is greater than %{inspect}"
           less_than_or_equal_to:
-            positive: "is less than or equal to {{inspect}}"
+            positive: "is less than or equal to %{inspect}"
           greater_than_or_equal_to:
-            positive: "is greater than or equal to {{inspect}}"
+            positive: "is greater than or equal to %{inspect}"
 
       validate_presence_of:
-        description: "require {{attributes}} to be set"
+        description: "require %{attributes} to be set"
         expectations:
-          allow_nil: "{{subject_name}} to require {{attribute}} to be set"
+          allow_nil: "%{subject_name} to require %{attribute} to be set"
 
       validate_uniqueness_of:
-        description: "require unique values for {{attributes}}"
+        description: "require unique values for %{attributes}"
         expectations:
-          responds_to_scope: "{{subject_name}} instance responds to {{method}}"
-          is_unique: "{{subject_name}} to require unique values for {{attribute}}"
-          case_sensitive: "{{subject_name}} to {{not}}be case sensitive on {{attribute}} validation"
-          valid_with_new_scope: "{{subject_name}} to be valid when {{attribute}} scope ({{method}}) change"
+          responds_to_scope: "%{subject_name} instance responds to %{method}"
+          is_unique: "%{subject_name} to require unique values for %{attribute}"
+          case_sensitive: "%{subject_name} to %{not}be case sensitive on %{attribute} validation"
+          valid_with_new_scope: "%{subject_name} to be valid when %{attribute} scope (%{method}) change"
         optionals:
           scope:
-            positive: "scoped to {{sentence}}"
+            positive: "scoped to %{sentence}"
           case_sensitive:
             positive: "case sensitive"
             negative: "case insensitive"

--- a/remarkable_i18n/pt-BR.yml
+++ b/remarkable_i18n/pt-BR.yml
@@ -5,8 +5,8 @@ pt-BR:
       should: "deve"
       should_not: "não deve"
       example_disabled: "Exemplo desativado"
-      failure_message_for_should: "Esperava que {{expectation}}"
-      failure_message_for_should_not: "Não esperava que {{expectation}}"
+      failure_message_for_should: "Esperava que %{expectation}"
+      failure_message_for_should_not: "Não esperava que %{expectation}"
 
       helpers:
         words_connector: ", "
@@ -14,121 +14,121 @@ pt-BR:
         last_word_connector: " e "
 
     action_controller:
-      responding: "respondendo para #{{verb}} {{action}}"
-      mime_type: "com {{format}}"
+      responding: "respondendo para #%{verb} %{action}"
+      mime_type: "com %{format}"
 
       assign_to:
-        description: "assinalar {{names}}"
+        description: "assinalar %{names}"
         expectations:
-          assigned_value: "ação assinalasse {{name}}, nenhum assinalamento ocorreu"
-          is_kind_of: "valor assinalado a {{name}} fosse um tipo de {{with_kind_of}}, obtive {{assign_class}}"
-          is_equal_value: "valor assinalado a {{name}} fosse igual a {{with}}, obtive {{assign_inspect}}"
+          assigned_value: "ação assinalasse %{name}, nenhum assinalamento ocorreu"
+          is_kind_of: "valor assinalado a %{name} fosse um tipo de %{with_kind_of}, obtive %{assign_class}"
+          is_equal_value: "valor assinalado a %{name} fosse igual a %{with}, obtive %{assign_inspect}"
         optionals:
           with_kind_of:
-            positive: "com um tipo de {{value}}"
+            positive: "com um tipo de %{value}"
 
       filter_params:
-        description: "filtre {{params}} parâmetros do log"
+        description: "filtre %{params} parâmetros do log"
         expectations:
           respond_to_filter_params: "controller respondesse para :filter_parameters (controller não está filtrando nenhum parâmetro)"
-          is_filtered: "{{param}} fosse filtrado, nenhum filtro ocorreu"
+          is_filtered: "%{param} fosse filtrado, nenhum filtro ocorreu"
 
       redirect_to:
-        description: "redirecione para {{expected}}"
+        description: "redirecione para %{expected}"
         expectations:
-          redirected: "redirecionasse para {{expected}}, nenhum redirecionamento ocorreu"
-          status_matches: "redirecionasse para {{expected}} com status {{with}}, obtive status {{status}}"
-          url_matches: "redirecionasse para {{expected}}, obtive redirecionamento para {{actual}}"
+          redirected: "redirecionasse para %{expected}, nenhum redirecionamento ocorreu"
+          status_matches: "redirecionasse para %{expected} com status %{with}, obtive status %{status}"
+          url_matches: "redirecionasse para %{expected}, obtive redirecionamento para %{actual}"
         optionals:
           with:
-            positive: "com status {{inspect}}"
+            positive: "com status %{inspect}"
 
       render_template:
         description: "renderize"
         expectations:
-          rendered: "template {{template}} fosse renderizado, nenhuma renderização ocorreu"
-          template_matches: "template {{template}} fosse renderizado, obtive {{actual_template}}"
-          layout_matches: "renderizasse com layout {{layout}}, obtive {{actual_layout}}"
-          status_matches: "renderizasse com status {{with}}, obtive {{actual_status}}"
-          body_matches: "renderizasse com conteúdo {{body}}, obtive {{actual_body}}"
-          content_type_matches: "renderizasse com content type {{content_type}}, obtive {{actual_content_type}}"
+          rendered: "template %{template} fosse renderizado, nenhuma renderização ocorreu"
+          template_matches: "template %{template} fosse renderizado, obtive %{actual_template}"
+          layout_matches: "renderizasse com layout %{layout}, obtive %{actual_layout}"
+          status_matches: "renderizasse com status %{with}, obtive %{actual_status}"
+          body_matches: "renderizasse com conteúdo %{body}, obtive %{actual_body}"
+          content_type_matches: "renderizasse com content type %{content_type}, obtive %{actual_content_type}"
         optionals:
           template:
-            positive: "template {{inspect}}"
+            positive: "template %{inspect}"
           layout:
-            positive: "com layout {{inspect}}"
+            positive: "com layout %{inspect}"
             negative: "sem layout"
           with:
-            positive: "com statys {{value}}"
+            positive: "com statys %{value}"
           body:
-            positive: "com conteúdo {{inspect}}"
+            positive: "com conteúdo %{inspect}"
           content_type:
-            positive: "com content type {{inspect}}"
+            positive: "com content type %{inspect}"
 
       respond_with:
         description: "responder"
         expectations:
-          status_matches: "respondesse com status {{with}}, obtive {{actual_status}}"
-          body_matches: "respondesse com corpo {{body}}, obtive {{actual_body}}"
-          content_type_matches: "respondesse com content type {{content_type}}, obtive {{actual_content_type}}"
+          status_matches: "respondesse com status %{with}, obtive %{actual_status}"
+          body_matches: "respondesse com corpo %{body}, obtive %{actual_body}"
+          content_type_matches: "respondesse com content type %{content_type}, obtive %{actual_content_type}"
         optionals:
           with:
-            positive: "com {{value}}"
+            positive: "com %{value}"
           body:
-            positive: "com conteúdo {{inspect}}"
+            positive: "com conteúdo %{inspect}"
           content_type:
-            positive: "com content type {{inspect}}"
+            positive: "com content type %{inspect}"
 
       route:
-        description: "tenha rotas {{method}} {{path}} de/para {{options}}"
+        description: "tenha rotas %{method} %{path} de/para %{options}"
         expectations:
-          map_to_path: "tivesse rotas de {{options}} para {{method}} {{path}}, obtive {{actual}}"
-          generate_params: "criasse {{options}} de {{method}} {{path}}, obtive {{actual}}"
+          map_to_path: "tivesse rotas de %{options} para %{method} %{path}, obtive %{actual}"
+          generate_params: "criasse %{options} de %{method} %{path}, obtive %{actual}"
 
       set_cookies:
-        description: "definir cookies {{keys}}"
+        description: "definir cookies %{keys}"
         expectations:
-          is_not_empty: "algum cookie ser definido, obtive {{cookies_inspect}}"
-          contains_value: "algum cookie ser definido para {{to}}, obtive {{cookies_inspect}}"
-          assigned_value: "cookie {{key}} ser definido, obtive {{cookies_inspect}}"
-          is_equal_value: "cookie {{key}} ser definido para {{to}}, obtive {{cookies_inspect}}"
+          is_not_empty: "algum cookie ser definido, obtive %{cookies_inspect}"
+          contains_value: "algum cookie ser definido para %{to}, obtive %{cookies_inspect}"
+          assigned_value: "cookie %{key} ser definido, obtive %{cookies_inspect}"
+          is_equal_value: "cookie %{key} ser definido para %{to}, obtive %{cookies_inspect}"
         optionals:
           to:
-            positive: "para {{inspect}}"
-            negative: "para {{inspect}}"
+            positive: "para %{inspect}"
+            negative: "para %{inspect}"
 
       set_session:
-        description: "set variável de sessão {{keys}}"
+        description: "set variável de sessão %{keys}"
         expectations:
-          is_not_empty: "qualquer variável de sessão fosse setada, obtive {{session_inspect}}"
-          contains_value: "qualquer variável de sessão fosse setada para {{to}}, obtive {{session_inspect}}"
-          assigned_value: "variável de sessão {{key}} fosse setada, obtive {{session_inspect}}"
-          is_equal_value: "variável de sessão {{key}} fosse setada para {{to}}, obtive {{session_inspect}}"
+          is_not_empty: "qualquer variável de sessão fosse setada, obtive %{session_inspect}"
+          contains_value: "qualquer variável de sessão fosse setada para %{to}, obtive %{session_inspect}"
+          assigned_value: "variável de sessão %{key} fosse setada, obtive %{session_inspect}"
+          is_equal_value: "variável de sessão %{key} fosse setada para %{to}, obtive %{session_inspect}"
         optionals:
           to:
-            positive: "para {{inspect}}"
-            negative: "para {{inspect}}"
+            positive: "para %{inspect}"
+            negative: "para %{inspect}"
 
       set_the_flash:
-        description: "setar mensagem flash {{keys}}"
+        description: "setar mensagem flash %{keys}"
         expectations:
-          is_not_empty: "qualquer mensagem flash fosse setada, obtive {{flash_inspect}}"
-          contains_value: "qualquer mensagem flash fosse setada para {{to}}, obtive {{flash_inspect}}"
-          assigned_value: "mensagem flash {{key}} fosse setada, obtive {{flash_inspect}}"
-          is_equal_value: "mensagem flash {{key}} fosse setada para {{to}}, obtive {{flash_inspect}}"
+          is_not_empty: "qualquer mensagem flash fosse setada, obtive %{flash_inspect}"
+          contains_value: "qualquer mensagem flash fosse setada para %{to}, obtive %{flash_inspect}"
+          assigned_value: "mensagem flash %{key} fosse setada, obtive %{flash_inspect}"
+          is_equal_value: "mensagem flash %{key} fosse setada para %{to}, obtive %{flash_inspect}"
         optionals:
           to:
-            positive: "para {{inspect}}"
-            negative: "para {{inspect}}"
+            positive: "para %{inspect}"
+            negative: "para %{inspect}"
 
     active_record:
       describe:
-        each: "{{key}} for {{value}}"
+        each: "%{key} for %{value}"
         prepend: "quando "
         connector: " e "
       expectations:
-        allow_nil: "{{subject_name}} {{not}} permitisse valores nulos para {{attribute}}"
-        allow_blank: "{{subject_name}} {{not}} permitisse valores vazios para {{attribute}}"
+        allow_nil: "%{subject_name} %{not} permitisse valores nulos para %{attribute}"
+        allow_blank: "%{subject_name} %{not} permitisse valores vazios para %{attribute}"
       optionals:
         allow_nil:
           positive: "permitindo valores nulos"
@@ -138,71 +138,71 @@ pt-BR:
           negative: "não permitindo valores vazios"
 
       accept_nested_attributes_for:
-        description: "aceite attributos aninhandos para {{associations}}"
+        description: "aceite attributos aninhandos para %{associations}"
         expectations:
-          association_exists: "{{subject_name}} tivesse associação {{association}}, mas não tem"
-          is_autosave: "{{subject_name}} tivesse associação {{association}} com autosave habilitado, obtive desabilitado"
-          responds_to_attributes: "{{subject_name}} respondesse para :{{association}}_attributes=, mas não responde"
-          allows_destroy: "{{subject_name}} com permissão para destruir igual a {{allow_destroy}}, obtive {{actual}}"
-          accepts: "{{subject_name}} to aceitasse atributos {{attributes}} para {{association}}, mas não aceita"
-          rejects: "{{subject_name}} to rejeitasse atributos {{attributes}} para {{association}}, mas não rejeita"
+          association_exists: "%{subject_name} tivesse associação %{association}, mas não tem"
+          is_autosave: "%{subject_name} tivesse associação %{association} com autosave habilitado, obtive desabilitado"
+          responds_to_attributes: "%{subject_name} respondesse para :%{association}_attributes=, mas não responde"
+          allows_destroy: "%{subject_name} com permissão para destruir igual a %{allow_destroy}, obtive %{actual}"
+          accepts: "%{subject_name} to aceitasse atributos %{attributes} para %{association}, mas não aceita"
+          rejects: "%{subject_name} to rejeitasse atributos %{attributes} para %{association}, mas não rejeita"
         optionals:
           allow_destroy:
             positive: "permitindo destruição"
             negative: "não permitindo destruição"
           accept:
-            positive: "aceitando {{sentence}}"
+            positive: "aceitando %{sentence}"
           reject:
-            positive: "rejeitando {{sentence}}"
+            positive: "rejeitando %{sentence}"
 
       allow_values_for:
-        description: "permitir {{in}} como valores para {{attributes}}"
+        description: "permitir %{in} como valores para %{attributes}"
         expectations:
-          is_valid: "{{subject_name}} fosse válido quando {{attribute}} é igual a {{value}}"
+          is_valid: "%{subject_name} fosse válido quando %{attribute} é igual a %{value}"
 
       allow_mass_assignment_of:
-        description: "permitir assinalamento em massa de {{attributes}}"
+        description: "permitir assinalamento em massa de %{attributes}"
         expectations:
-          allows: "{{subject_name}} permitisse assinalamento em massa ({{subject_name}} está protegendo {{protected_attributes}})"
-          is_protected: "{{subject_name}} permitisse o assinalamento em massa de {{attribute}} ({{subject_name}} está protegendo {{attribute}})"
-          is_accessible: "{{subject_name}} permitisse o assinalamento em massa de {{attribute}} ({{subject_name}} não tornou {{attribute}} accessível)"
+          allows: "%{subject_name} permitisse assinalamento em massa (%{subject_name} está protegendo %{protected_attributes})"
+          is_protected: "%{subject_name} permitisse o assinalamento em massa de %{attribute} (%{subject_name} está protegendo %{attribute})"
+          is_accessible: "%{subject_name} permitisse o assinalamento em massa de %{attribute} (%{subject_name} não tornou %{attribute} accessível)"
         negative_expectations:
-          allows: "{{subject_name}} permitisse assinalamento em massa ({{subject_name}} tornou {{accessible_attributes}} accessível)"
-          is_protected: "{{subject_name}} permitisse o assinalamento em massa de {{attribute}} ({{subject_name}} não está protegendo {{attribute}})"
-          is_accessible: "{{subject_name}} permitisse o assinalamento em massa de {{attribute}} ({{subject_name}} tornou {{attribute}} accessível)"
+          allows: "%{subject_name} permitisse assinalamento em massa (%{subject_name} tornou %{accessible_attributes} accessível)"
+          is_protected: "%{subject_name} permitisse o assinalamento em massa de %{attribute} (%{subject_name} não está protegendo %{attribute})"
+          is_accessible: "%{subject_name} permitisse o assinalamento em massa de %{attribute} (%{subject_name} tornou %{attribute} accessível)"
 
       association:
         belongs_to: pertencer a
         has_many: possuir vários(as)
         has_and_belongs_to_many: possuir e pertencer a vários(as)
         has_one: possuir um(a)
-        description: "{{macro}} {{associations}}"
+        description: "%{macro} %{associations}"
         expectations:
-          association_exists: "{{subject_name}} pudesse {{macro}} {{association}}, mas associação não existe"
-          macro_matches: "{{subject_name}} pudesse {{macro}} {{association}}, obtive que {{subject_name}} deve {{actual_macro}} {{association}}"
-          through_exists: "{{subject_name}} pudesse {{macro}} {{association}} através de {{through}}, obtive que \"through_association\" não existe"
-          source_exists: "{{subject_name}} pudesse {{macro}} {{association}} através de {{through}}, obtive que \"source association\" não existe"
-          klass_exists: "{{subject_name}} records {{macro}} {{association}}, mas a classe da associação não existe"
-          join_table_exists: "tabela de junção {{join_table}} existisse, mas não existe"
-          foreign_key_exists: "chave estrangeira {{foreign_key}} existisse em {{foreign_key_table}}, mas não existe"
-          polymorphic_exists: "{{subject_table}} tivesse {{polymorphic_column}} como coluna, mas não tem"
-          counter_cache_exists: "{{reflection_table}} tivesse {{counter_cache_column}} como coluna, mas não tem"
-          options_match: "{{subject_name}} tivesse {{macro}} {{association}} com as opções {{options}}, obtive {{actual}}"
+          association_exists: "%{subject_name} pudesse %{macro} %{association}, mas associação não existe"
+          macro_matches: "%{subject_name} pudesse %{macro} %{association}, obtive que %{subject_name} deve %{actual_macro} %{association}"
+          through_exists: "%{subject_name} pudesse %{macro} %{association} através de %{through}, obtive que \"through_association\" não existe"
+          source_exists: "%{subject_name} pudesse %{macro} %{association} através de %{through}, obtive que \"source association\" não existe"
+          klass_exists: "%{subject_name} records %{macro} %{association}, mas a classe da associação não existe"
+          join_table_exists: "tabela de junção %{join_table} existisse, mas não existe"
+          foreign_key_exists: "chave estrangeira %{foreign_key} existisse em %{foreign_key_table}, mas não existe"
+          polymorphic_exists: "%{subject_table} tivesse %{polymorphic_column} como coluna, mas não tem"
+          counter_cache_exists: "%{reflection_table} tivesse %{counter_cache_column} como coluna, mas não tem"
+          options_match: "%{subject_name} tivesse %{macro} %{association} com as opções %{options}, obtive %{actual}"
         optionals:
           through:
-            positive: "através de {{value}}"
+            positive: "através de %{value}"
           source:
-            positive: "com origem {{inspect}}"
+            positive: "com origem %{inspect}"
           source_type:
-            positive: "com tipo de origem {{inspect}}"
+            positive: "com tipo de origem %{inspect}"
           class_name:
-            positive: "com nome de classe {{inspect}}"
+            positive: "com nome de classe %{inspect}"
           foreign_key:
-            positive: "com chave estrangeira {{inspect}}"
+            positive: "com chave estrangeira %{inspect}"
           dependent:
-            positive: "com dependência {{inspect}}"
+            positive: "com dependência %{inspect}"
           join_table:
-            positive: "com tabela de junção {{inspect}}"
+            positive: "com tabela de junção %{inspect}"
           uniq:
             positive: "com registros únicos"
             negative: "sem registros únicos"
@@ -216,136 +216,136 @@ pt-BR:
             positive: "salvando automaticamente registros associados"
             negative: "não salvando automaticamente registros associados"
           as:
-            positive: "através de uma interface polimórfica {{inspect}}"
+            positive: "através de uma interface polimórfica %{inspect}"
           counter_cache:
-            positive: "com coluna de cache {{inspect}}"
+            positive: "com coluna de cache %{inspect}"
             negative: "sem coluna de cache"
           select:
-            positive: "selecionando {{inspect}}"
+            positive: "selecionando %{inspect}"
           conditions:
-            positive: "com condições {{inspect}}"
+            positive: "com condições %{inspect}"
           include:
-            positive: "incluindo {{inspect}}"
+            positive: "incluindo %{inspect}"
           group:
-            positive: "agrupando por {{inspect}}"
+            positive: "agrupando por %{inspect}"
           having:
-            positive: "contendo {{inspect}}"
+            positive: "contendo %{inspect}"
           order:
-            positive: "com ordem {{inspect}}"
+            positive: "com ordem %{inspect}"
           limit:
-            positive: "com limite {{inspect}}"
+            positive: "com limite %{inspect}"
           offset:
-            positive: "com offset {{inspect}}"
+            positive: "com offset %{inspect}"
 
       have_column:
-        description: "haver coluna(s) {{columns}}"
+        description: "haver coluna(s) %{columns}"
         expectations:
-          column_exists: "{{subject_name}} houvesse coluna chamada {{column}}"
-          options_match: "{{subject_name}} houvesse coluna {{column}} com configurações {{options}}, obtive {{actual}}"
+          column_exists: "%{subject_name} houvesse coluna chamada %{column}"
+          options_match: "%{subject_name} houvesse coluna %{column} com configurações %{options}, obtive %{actual}"
         optionals:
           type:
-            positive: "com tipo {{inspect}}"
+            positive: "com tipo %{inspect}"
           null:
             positive: "permitindo valores nulos"
             negative: "não permitindo valores nulos"
           default:
-            positive: "com valor default {{inspect}}"
-            negative: "com valor default {{inspect}}"
+            positive: "com valor default %{inspect}"
+            negative: "com valor default %{inspect}"
           limit:
-            positive: "com limite {{inspect}}"
+            positive: "com limite %{inspect}"
 
       have_default_scope:
-        description: "haver escopo padrão com {{options}}"
+        description: "haver escopo padrão com %{options}"
         expectations:
-          options_match: "tivesse escopo padrão {{options}}, obtive {{actual}}"
+          options_match: "tivesse escopo padrão %{options}, obtive %{actual}"
 
       have_index:
-        description: "haver índice para coluna(s) {{columns}}"
+        description: "haver índice para coluna(s) %{columns}"
         expectations:
-          index_exists: "índice {{column}} existisse na tabela {{table_name}}"
-          is_unique: "índice em {{column}} com valores unicos igual a {{unique}}, obtive {{actual}}"
+          index_exists: "índice %{column} existisse na tabela %{table_name}"
+          is_unique: "índice em %{column} com valores unicos igual a %{unique}, obtive %{actual}"
         optionals:
           unique:
             positive: "com valores únicos"
             negative: "sem valores únicos"
           table_name:
-            positive: "na tabela {{value}}"
+            positive: "na tabela %{value}"
 
       have_readonly_attributes:
-        description: "tornar {{attributes}} apenas leitura"
+        description: "tornar %{attributes} apenas leitura"
         expectations:
-          is_readonly: "{{subject_name}} tornasse {{attribute}} apenas leitura, obtive {{actual}}"
+          is_readonly: "%{subject_name} tornasse %{attribute} apenas leitura, obtive %{actual}"
 
       have_scope:
-        description: "haver escopo {{options}} quando {{scope_name}} é chamado"
+        description: "haver escopo %{options} quando %{scope_name} é chamado"
         expectations:
-          is_scope: "{{scope_name}} quando chamado em {{subject_name}} retornasse um instância de ActiveRecord::NamedScope::Scope"
-          options_match: "{{scope_name}} quando chamado em {{subject_name}} houvesse escopo {{options}}, obtive {{actual}}"
+          is_scope: "%{scope_name} quando chamado em %{subject_name} retornasse um instância de ActiveRecord::NamedScope::Scope"
+          options_match: "%{scope_name} quando chamado em %{subject_name} houvesse escopo %{options}, obtive %{actual}"
         optionals:
           with:
-            positive: "com {{inspect}} como argumento"
+            positive: "com %{inspect} como argumento"
 
       validate_acceptance_of:
-        description: "exigir que {{attributes}} sejam aceitos"
+        description: "exigir que %{attributes} sejam aceitos"
         expectations:
-          requires_acceptance: "{{subject_name}} fosse inválido se {{attribute}} não foi aceito"
-          accept_is_valid: "{{subject_name}} fosse válido quando {{attribute}} é aceito com valor {{accept}}"
+          requires_acceptance: "%{subject_name} fosse inválido se %{attribute} não foi aceito"
+          accept_is_valid: "%{subject_name} fosse válido quando %{attribute} é aceito com valor %{accept}"
         optionals:
           accept:
-            positive: "com valor {{inspect}}"
+            positive: "com valor %{inspect}"
 
       validate_associated:
-        description: "exigir que associação {{associations}} seja válida"
+        description: "exigir que associação %{associations} seja válida"
         expectations:
-          is_valid: "{{subject_name}} fosse válida quando {{association}} é inválido"
+          is_valid: "%{subject_name} fosse válida quando %{association} é inválido"
 
       validate_confirmation_of:
-        description: "exigir que {{attributes}} seja confirmado"
+        description: "exigir que %{attributes} seja confirmado"
         expectations:
-          responds_to_confirmation: "{{subject_name}} respondesse a {{attribute}}_confirmation"
-          confirms: "{{subject_name}} fosse válido somente quando {{attribute}} é confirmado"
+          responds_to_confirmation: "%{subject_name} respondesse a %{attribute}_confirmation"
+          confirms: "%{subject_name} fosse válido somente quando %{attribute} é confirmado"
 
       validate_exclusion_of:
-        description: "exigir exclusão de {{attributes}} de {{in}}"
+        description: "exigir exclusão de %{attributes} de %{in}"
         expectations:
-          is_valid: "{{subject_name}} fosse válido quando {{attribute}} é igual a {{value}}"
-          is_invalid: "{{subject_name}} fosse inválido quando {{attribute}} é igual a {{value}}"
+          is_valid: "%{subject_name} fosse válido quando %{attribute} é igual a %{value}"
+          is_invalid: "%{subject_name} fosse inválido quando %{attribute} é igual a %{value}"
 
       validate_inclusion_of:
-        description: "exigir inclusão de {{attributes}} em {{in}}"
+        description: "exigir inclusão de %{attributes} em %{in}"
         expectations:
-          is_valid: "{{subject_name}} fosse válido quando {{attribute}} é igual a {{value}}"
-          is_invalid: "{{subject_name}} fosse inválido quando {{attribute}} é igual a {{value}}"
+          is_valid: "%{subject_name} fosse válido quando %{attribute} é igual a %{value}"
+          is_invalid: "%{subject_name} fosse inválido quando %{attribute} é igual a %{value}"
 
       validate_length_of:
-        description: "garantir que o tamanho de {{attributes}}"
+        description: "garantir que o tamanho de %{attributes}"
         expectations:
-          less_than_min_length: "{{subject_name}} fosse inválido quando tamanho de {{attribute}}  é menor que {{minimum}} caracteres"
-          exactly_min_length: "{{subject_name}} fosse válido quando tamanho de {{attribute}} é {{minimum}} caracteres"
-          more_than_max_length: "{{subject_name}} fosse inválido quando tamanho de {{attribute}} é mais que {{maximum}} caracteres"
-          exactly_max_length: "{{subject_name}} fosse válido quando tamannho de {{attribute}} é {{maximum}} caracteres"
+          less_than_min_length: "%{subject_name} fosse inválido quando tamanho de %{attribute}  é menor que %{minimum} caracteres"
+          exactly_min_length: "%{subject_name} fosse válido quando tamanho de %{attribute} é %{minimum} caracteres"
+          more_than_max_length: "%{subject_name} fosse inválido quando tamanho de %{attribute} é mais que %{maximum} caracteres"
+          exactly_max_length: "%{subject_name} fosse válido quando tamannho de %{attribute} é %{maximum} caracteres"
         optionals:
           within:
-            positive: "seja entre {{inspect}} caracteres"
+            positive: "seja entre %{inspect} caracteres"
           maximum:
-            positive: "seja no máximo {{inspect}} caracteres"
+            positive: "seja no máximo %{inspect} caracteres"
           minimum:
-            positive: "seja no mínimo {{inspect}} caracteres"
+            positive: "seja no mínimo %{inspect} caracteres"
           is:
-            positive: "seja igual a {{inspect}} caracteres"
+            positive: "seja igual a %{inspect} caracteres"
           with_kind_of:
-            positive: "com um tipo de {{value}}"
+            positive: "com um tipo de %{value}"
 
       validate_numericality_of:
-        description: "permitir apenas números para {{attributes}}"
+        description: "permitir apenas números para %{attributes}"
         expectations:
-          only_numeric_values: "{{subject_name}} permitisse apenas números para {{attribute}}"
-          only_integer: "{{subject_name}} {{not}} permitisse somente valores inteiros para {{attribute}}"
-          only_even: "{{subject_name}} permitisse apenas valores pares em {{attribute}}"
-          only_odd: "{{subject_name}} permitisse apenas valores ímpares em {{attribute}}"
-          equals_to: "{{subject_name}} fosse válido quando {{attribute}} é igual a {{count}}"
-          more_than_maximum: "{{subject_name}} fosse inválido quando {{attribute}} é maior que {{count}}"
-          less_than_minimum: "{{subject_name}} fosse inválido quando {{attribute}} é menor que {{count}}"
+          only_numeric_values: "%{subject_name} permitisse apenas números para %{attribute}"
+          only_integer: "%{subject_name} %{not} permitisse somente valores inteiros para %{attribute}"
+          only_even: "%{subject_name} permitisse apenas valores pares em %{attribute}"
+          only_odd: "%{subject_name} permitisse apenas valores ímpares em %{attribute}"
+          equals_to: "%{subject_name} fosse válido quando %{attribute} é igual a %{count}"
+          more_than_maximum: "%{subject_name} fosse inválido quando %{attribute} é maior que %{count}"
+          less_than_minimum: "%{subject_name} fosse inválido quando %{attribute} é menor que %{count}"
         optionals:
           only_integer:
             positive: "permitindo apenas valores inteiros"
@@ -354,31 +354,31 @@ pt-BR:
           even:
             positive: "permitindo apenas valores pares"
           equal_to:
-            positive: "iguais a {{inspect}}"
+            positive: "iguais a %{inspect}"
           less_than:
-            positive: "menores que {{inspect}}"
+            positive: "menores que %{inspect}"
           greater_than:
-            positive: "maiores que {{inspect}}"
+            positive: "maiores que %{inspect}"
           less_than_or_equal_to:
-            positive: "menores ou iguais a {{inspect}}"
+            positive: "menores ou iguais a %{inspect}"
           greater_than_or_equal_to:
-            positive: "maiores ou iguais a {{inspect}}"
+            positive: "maiores ou iguais a %{inspect}"
 
       validate_presence_of:
-        description: "exigir que {{attributes}} seja(m) setado(s)"
+        description: "exigir que %{attributes} seja(m) setado(s)"
         expectations:
-          allow_nil: "{{subject_name}} exigisse que {{attribute}} fosse setado"
+          allow_nil: "%{subject_name} exigisse que %{attribute} fosse setado"
 
       validate_uniqueness_of:
-        description: "exigir valores únicos para {{attributes}}"
+        description: "exigir valores únicos para %{attributes}"
         expectations:
-          responds_to_scope: "isntância de {{subject_name}} respondesse para {{method}}"
-          is_unique: "{{subject_name}} exigisse valores únicos para {{attribute}}"
-          case_sensitive: "{{subject_name}} {{not}} fosse case sensitive quando validando {{attribute}}"
-          valid_with_new_scope: "{{subject_name}} fosse válido quando {{attribute}} escopo ({{method}}) alterasse"
+          responds_to_scope: "isntância de %{subject_name} respondesse para %{method}"
+          is_unique: "%{subject_name} exigisse valores únicos para %{attribute}"
+          case_sensitive: "%{subject_name} %{not} fosse case sensitive quando validando %{attribute}"
+          valid_with_new_scope: "%{subject_name} fosse válido quando %{attribute} escopo (%{method}) alterasse"
         optionals:
           scope:
-            positive: "com escopo {{sentence}}"
+            positive: "com escopo %{sentence}"
           case_sensitive:
             positive: "case sensitive"
             negative: "case insensitive"

--- a/remarkable_rails/lib/remarkable_rails/action_controller/macro_stubs.rb
+++ b/remarkable_rails/lib/remarkable_rails/action_controller/macro_stubs.rb
@@ -363,8 +363,8 @@ module Remarkable
         #   locale:
         #     remarkable:
         #       action_controller:
-        #         responding: "responding to #{{verb}} {{action}}"
-        #         mime_type: "with {{format}} ({{content_type}})"
+        #         responding: "responding to #%{verb} %{action}"
+        #         mime_type: "with %{format} (%{content_type})"
         #
         # And load the locale file with:
         #
@@ -379,7 +379,7 @@ module Remarkable
             verb   = verb.to_s
 
             description = Remarkable.t 'remarkable.action_controller.responding',
-                                        :default => "responding to \#{{verb}} {{action}}",
+                                        :default => "responding to \#%{verb} %{action}",
                                         :verb => verb.sub('!', '').upcase, :action => action
 
             send_args = [ verb, action, options ]

--- a/remarkable_rails/locale/en.yml
+++ b/remarkable_rails/locale/en.yml
@@ -1,110 +1,110 @@
 en:
   remarkable:
     action_controller:
-      responding: "responding to #{{verb}} {{action}}"
-      mime_type: "with {{format}}"
+      responding: "responding to #%{verb} %{action}"
+      mime_type: "with %{format}"
 
       assign_to:
-        description: "assign {{names}}"
+        description: "assign %{names}"
         expectations:
-          assigned_value: "action to assign {{name}}, got no assignment"
-          is_kind_of: "assign {{name}} to be kind of {{with_kind_of}}, got a {{assign_class}}"
-          is_equal_value: "assign {{name}} to be equal to {{with}}, got {{assign_inspect}}"
+          assigned_value: "action to assign %{name}, got no assignment"
+          is_kind_of: "assign %{name} to be kind of %{with_kind_of}, got a %{assign_class}"
+          is_equal_value: "assign %{name} to be equal to %{with}, got %{assign_inspect}"
         optionals:
           with_kind_of:
-            positive: "with kind of {{value}}"
+            positive: "with kind of %{value}"
 
       filter_params:
-        description: "filter {{params}} parameters from log"
+        description: "filter %{params} parameters from log"
         expectations:
           respond_to_filter_params: "controller to respond to filter_parameters (controller is not filtering any parameter)"
-          is_filtered: "{{param}} to be filtered, got no filtering"
+          is_filtered: "%{param} to be filtered, got no filtering"
 
       redirect_to:
-        description: "redirect to {{expected}}"
+        description: "redirect to %{expected}"
         expectations:
-          redirected: "redirect to {{expected}}, got no redirect"
-          status_matches: "redirect to {{expected}} with status {{with}}, got status {{status}}"
-          url_matches: "redirect to {{expected}}, got redirect to {{actual}}"
+          redirected: "redirect to %{expected}, got no redirect"
+          status_matches: "redirect to %{expected} with status %{with}, got status %{status}"
+          url_matches: "redirect to %{expected}, got redirect to %{actual}"
         optionals:
           with:
-            positive: "with status {{inspect}}"
+            positive: "with status %{inspect}"
 
       render_template:
         description: "render"
         expectations:
-          rendered: "template {{template}} to be rendered, got no render"
-          template_matches: "template {{template}} to be rendered, got {{actual_template}}"
-          layout_matches: "to render with layout {{layout}}, got {{actual_layout}}"
-          status_matches: "to render with status {{with}}, got {{actual_status}}"
-          body_matches: "to render with body {{body}}, got {{actual_body}}"
-          content_type_matches: "to render with content type {{content_type}}, got {{actual_content_type}}"
+          rendered: "template %{template} to be rendered, got no render"
+          template_matches: "template %{template} to be rendered, got %{actual_template}"
+          layout_matches: "to render with layout %{layout}, got %{actual_layout}"
+          status_matches: "to render with status %{with}, got %{actual_status}"
+          body_matches: "to render with body %{body}, got %{actual_body}"
+          content_type_matches: "to render with content type %{content_type}, got %{actual_content_type}"
         optionals:
           template:
-            positive: "template {{inspect}}"
+            positive: "template %{inspect}"
           layout:
-            positive: "with layout {{inspect}}"
+            positive: "with layout %{inspect}"
             negative: "with no layout"
           with:
-            positive: "with {{value}}"
+            positive: "with %{value}"
           body:
-            positive: "with body {{inspect}}"
+            positive: "with body %{inspect}"
           content_type:
-            positive: "with content type {{inspect}}"
+            positive: "with content type %{inspect}"
 
       respond_with:
         description: "respond"
         expectations:
-          status_matches: "to respond with status {{with}}, got {{actual_status}}"
-          body_matches: "to respond with body {{body}}, got {{actual_body}}"
-          content_type_matches: "to respond with content type {{content_type}}, got {{actual_content_type}}"
+          status_matches: "to respond with status %{with}, got %{actual_status}"
+          body_matches: "to respond with body %{body}, got %{actual_body}"
+          content_type_matches: "to respond with content type %{content_type}, got %{actual_content_type}"
         optionals:
           with:
-            positive: "with {{value}}"
+            positive: "with %{value}"
           body:
-            positive: "with body {{inspect}}"
+            positive: "with body %{inspect}"
           content_type:
-            positive: "with content type {{inspect}}"
+            positive: "with content type %{inspect}"
 
       route:
-        description: "route {{method}} {{path}} to/from {{options}}"
+        description: "route %{method} %{path} to/from %{options}"
         expectations:
-          map_to_path: "to map {{options}} to {{method}} {{path}}, got {{actual}}"
-          generate_params: "to generate params {{options}} from {{method}} {{path}}, got {{actual}}"
+          map_to_path: "to map %{options} to %{method} %{path}, got %{actual}"
+          generate_params: "to generate params %{options} from %{method} %{path}, got %{actual}"
 
       set_cookies:
-        description: "set cookies {{keys}}"
+        description: "set cookies %{keys}"
         expectations:
-          is_not_empty: "any cookie to be set, got {{cookies_inspect}}"
-          contains_value: "any cookie to be set to {{to}}, got {{cookies_inspect}}"
-          assigned_value: "cookie {{key}} to be set, got {{cookies_inspect}}"
-          is_equal_value: "cookie {{key}} to be set to {{to}}, got {{cookies_inspect}}"
+          is_not_empty: "any cookie to be set, got %{cookies_inspect}"
+          contains_value: "any cookie to be set to %{to}, got %{cookies_inspect}"
+          assigned_value: "cookie %{key} to be set, got %{cookies_inspect}"
+          is_equal_value: "cookie %{key} to be set to %{to}, got %{cookies_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 
       set_session:
-        description: "set session variable {{keys}}"
+        description: "set session variable %{keys}"
         expectations:
-          is_not_empty: "any session variable to be set, got {{session_inspect}}"
-          contains_value: "any session variable to be set to {{to}}, got {{session_inspect}}"
-          assigned_value: "session variable {{key}} to be set, got {{session_inspect}}"
-          is_equal_value: "session variable {{key}} to be set to {{to}}, got {{session_inspect}}"
+          is_not_empty: "any session variable to be set, got %{session_inspect}"
+          contains_value: "any session variable to be set to %{to}, got %{session_inspect}"
+          assigned_value: "session variable %{key} to be set, got %{session_inspect}"
+          is_equal_value: "session variable %{key} to be set to %{to}, got %{session_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 
       set_the_flash:
-        description: "set the flash message {{keys}}"
+        description: "set the flash message %{keys}"
         expectations:
-          is_not_empty: "any flash message to be set, got {{flash_inspect}}"
-          contains_value: "any flash message to be set to {{to}}, got {{flash_inspect}}"
-          assigned_value: "flash message {{key}} to be set, got {{flash_inspect}}"
-          is_equal_value: "flash message {{key}} to be set to {{to}}, got {{flash_inspect}}"
+          is_not_empty: "any flash message to be set, got %{flash_inspect}"
+          contains_value: "any flash message to be set to %{to}, got %{flash_inspect}"
+          assigned_value: "flash message %{key} to be set, got %{flash_inspect}"
+          is_equal_value: "flash message %{key} to be set to %{to}, got %{flash_inspect}"
         optionals:
           to:
-            positive: "to {{inspect}}"
-            negative: "to {{inspect}}"
+            positive: "to %{inspect}"
+            negative: "to %{inspect}"
 


### PR DESCRIPTION
Replaced {{key}} deprecated interpolation syntax in Rails >= 2.3.9 for %{key} new interpolation syntay.
I did in all .yml locale files. 

Issue 16
https://github.com/carlosbrando/remarkable/issues#issue/16
