### PR TITLE
Fixing deprecation message of Rails 3.1.1

### DIFF
--- a/remarkable_activerecord/lib/remarkable_activerecord/matchers/association_matcher.rb
+++ b/remarkable_activerecord/lib/remarkable_activerecord/matchers/association_matcher.rb
@@ -94,7 +94,7 @@ module Remarkable
           end
 
           def reflection_foreign_key
-            reflection.primary_key_name.to_s
+            (reflection.respond_to?(:foreign_key) ? reflection.foreign_key : reflection.primary_key_name).to_s
           end
 
           def table_has_column?(klass, table_name, column)


### PR DESCRIPTION
DEPRECATION WARNING: primary_key_name is deprecated and will be removed from Rails 3.2 (use foreign_key instead). (called from reflection_foreign_key at /Users/maksar/.rvm/gems/ruby-1.9.3-p0@tc_portal/gems/remarkable_activerecord-4.0.0.alpha4/lib/remarkable/active_record/matchers/association_matcher.rb:97)
